### PR TITLE
Add initial VLANs interface

### DIFF
--- a/app/controllers/vlans_controller.rb
+++ b/app/controllers/vlans_controller.rb
@@ -1,4 +1,20 @@
 class VlansController < ApplicationController
+  before_action :set_vlan, only: [:show]
+
   def show
+  end
+
+  def index
+    @vlans = Vlan.all
+  end
+
+  private
+
+  def set_vlan
+    @vlan = Vlan.find(vlan_id)
+  end
+
+  def vlan_id
+    params.fetch(:id)
   end
 end

--- a/app/controllers/vlans_controller.rb
+++ b/app/controllers/vlans_controller.rb
@@ -1,0 +1,4 @@
+class VlansController < ApplicationController
+  def show
+  end
+end

--- a/app/models/vlan.rb
+++ b/app/models/vlan.rb
@@ -1,0 +1,3 @@
+class Vlan < ApplicationRecord
+  audited
+end

--- a/app/views/vlans/index.html.erb
+++ b/app/views/vlans/index.html.erb
@@ -1,0 +1,33 @@
+<div>
+  <h2 class="govuk-heading-l">VLANs</h2>
+
+  <% if can? :create, Vlan %>
+    <%= link_to "Create a new VLAN", new_vlan_path, class: "govuk-button" %>
+  <% end %>
+
+  <table class="govuk-table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header">VLAN</th>
+        <th scope="col" class="govuk-table__header">
+          <span class="govuk-visually-hidden">Actions</span>
+        </th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+      <% @vlans.each do |vlan| %>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell"><%= vlan.vlan %></td>
+          <td class="govuk-table__cell">
+            <% if can? :manage, Vlan %>
+              <%= link_to "Manage", vlan_path(vlan), class: "govuk-link" %>
+              <%= link_to "Delete", vlan_path(vlan), class:"govuk-link", method: :delete %>
+            <% else %>
+              <%= link_to "View", vlan_path(vlan), class: "govuk-link" %>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/vlans/show.html.erb
+++ b/app/views/vlans/show.html.erb
@@ -1,0 +1,13 @@
+<h2 class="govuk-heading-l">VLAN <%= @vlan.vlan %></h2>
+
+<dl class="govuk-summary-list">
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">VLAN</dt>
+    <dd class="govuk-summary-list__value"><%= @vlan.vlan %></dd>
+    <dd class="govuk-summary-list__actions">
+      <%= link_to edit_vlan_path(@vlan), class: "govuk-link" do %>
+        Change<span class="govuk-visually-hidden"> VLAN</span>
+      <% end %>
+    </dd>
+  </div>
+</dl>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
     match "sign_out", to: "devise/sessions#destroy", as: :destroy_user_session, via: [:get, :delete]
   end
 
-  resources :sites
+  resources :sites, :vlans
 
   get "/healthcheck", to: "monitoring#healthcheck"
 

--- a/db/migrate/20210628112426_create_vlans.rb
+++ b/db/migrate/20210628112426_create_vlans.rb
@@ -1,0 +1,11 @@
+class CreateVlans < ActiveRecord::Migration[6.1]
+  def change
+    create_table :vlans do |t|
+      t.integer :vlan, null: false
+      t.string :common_name, null: false, unique: true
+      t.string :remote_ip, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210629091103_create_users.rb
+++ b/db/migrate/20210629091103_create_users.rb
@@ -1,0 +1,11 @@
+class CreateUsers < ActiveRecord::Migration[6.1]
+  def change
+    create_table :users do |t|
+      t.string :provider
+      t.string :uid
+      t.boolean :editor, default: false
+      t.string :email
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_14_102047) do
+ActiveRecord::Schema.define(version: 2021_06_29_091103) do
+
   create_table "audits", charset: "utf8", force: :cascade do |t|
     t.integer "auditable_id"
     t.string "auditable_type"
@@ -40,11 +41,20 @@ ActiveRecord::Schema.define(version: 2020_10_14_102047) do
   end
 
   create_table "users", charset: "utf8", force: :cascade do |t|
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
     t.string "provider"
     t.string "uid"
     t.boolean "editor", default: false
     t.string "email"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
+
+  create_table "vlans", charset: "utf8", force: :cascade do |t|
+    t.integer "vlan", null: false
+    t.string "common_name", null: false
+    t.string "remote_ip", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2021_06_29_091103) do
-
   create_table "audits", charset: "utf8", force: :cascade do |t|
     t.integer "auditable_id"
     t.string "auditable_type"
@@ -56,5 +55,4 @@ ActiveRecord::Schema.define(version: 2021_06_29_091103) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end
-
 end

--- a/spec/acceptance/vlan/show_vlan_spec.rb
+++ b/spec/acceptance/vlan/show_vlan_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+describe "showing a vlan", type: :feature do
+  context "when the user is unauthenticated" do
+    it "does not allow viewing vlans" do
+      visit "/vlans/nonexistant-vlan-id"
+
+      expect(page).to have_content "You need to sign in or sign up before continuing."
+    end
+  end
+end

--- a/spec/acceptance/vlan/show_vlan_spec.rb
+++ b/spec/acceptance/vlan/show_vlan_spec.rb
@@ -8,4 +8,22 @@ describe "showing a vlan", type: :feature do
       expect(page).to have_content "You need to sign in or sign up before continuing."
     end
   end
+
+  context "when the user is authenticated" do
+    before do
+      login_as create(:user, :reader)
+    end
+
+    context "when the vlan exists" do
+      let!(:vlan) { create :vlan }
+
+      it "allows viewing vlans" do
+        visit "/vlans"
+
+        click_on "View", match: :first
+
+        expect(page).to have_content vlan.name
+      end
+    end
+  end
 end

--- a/spec/acceptance/vlan/show_vlan_spec.rb
+++ b/spec/acceptance/vlan/show_vlan_spec.rb
@@ -22,7 +22,7 @@ describe "showing a vlan", type: :feature do
 
         click_on "View", match: :first
 
-        expect(page).to have_content vlan.name
+        expect(page).to have_content vlan.vlan
       end
     end
   end

--- a/spec/factories/vlans.rb
+++ b/spec/factories/vlans.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :vlan do
+    sequence(:common_name) { |n| "VLAN #{n}" }
+    sequence(:remote_ip) { |n| "10.0.0.#{n}" }
+  end
+end

--- a/spec/factories/vlans.rb
+++ b/spec/factories/vlans.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :vlan do
+    sequence(:vlan) { |n| n }
     sequence(:common_name) { |n| "VLAN #{n}" }
     sequence(:remote_ip) { |n| "10.0.0.#{n}" }
   end

--- a/spec/presenters/audit_presenter_spec.rb
+++ b/spec/presenters/audit_presenter_spec.rb
@@ -16,6 +16,5 @@ describe AuditPresenter do
 
       expect(presenter.name).to eq("Site (Foobar)")
     end
-
   end
 end


### PR DESCRIPTION
# What
- Fix schema and users migration
- Add VLANs controller and Model
- Add Views to allow viewing VLANs

# Why
- To add the basic components that will allow us implementing the VLAN journey

# Screenshots
![image](https://user-images.githubusercontent.com/22743709/123925645-069fa100-d983-11eb-97a3-97b44d7c7ed8.png)

# Notes
We added a placeholder /vlan page, this is where a user will be able to view the exiting vlans
