### PR TITLE
Allow deleting policies

### DIFF
--- a/app/controllers/policies_controller.rb
+++ b/app/controllers/policies_controller.rb
@@ -1,5 +1,5 @@
 class PoliciesController < ApplicationController
-  before_action :set_policy, only: [:show]
+  before_action :set_policy, only: [:show, :edit, :update, :destroy]
 
   def new
     @policy = Policy.new
@@ -24,6 +24,19 @@ class PoliciesController < ApplicationController
   def show
   end
 
+  def destroy
+    authorize! :destroy, @policy
+    if confirmed?
+      if @policy.destroy
+        redirect_to policies_path, notice: "Successfully deleted policy. "
+      else
+        redirect_to policy_path(@policy), error: "Failed to delete the policy"
+      end
+    else
+      render "policies/destroy"
+    end
+  end
+
   private
 
   def policy_params
@@ -36,5 +49,9 @@ class PoliciesController < ApplicationController
 
   def set_policy
     @policy = Policy.find(policy_id)
+  end
+
+  def confirmed?
+    params.fetch(:confirm, false)
   end
 end

--- a/app/views/policies/destroy.html.erb
+++ b/app/views/policies/destroy.html.erb
@@ -1,0 +1,34 @@
+<h2 class="govuk-heading-l">Are you sure you want to delete this policy?</h2>
+
+<div class="govuk-inset-text">
+  <h4 class="govuk-heading-s">Policy name:</h4>
+  <p class="govuk-body"><%= @policy.name %></p>
+</div>
+
+<div class="govuk-warning-text">
+  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+  <strong class="govuk-warning-text__text">
+    <span class="govuk-warning-text__assistive">Warning</span>
+      Deleting a policy cannot be undone.
+  </strong>
+</div>
+
+<%= button_to "Delete policy", policy_path(@policy),
+  method: :delete,
+  class: "govuk-button govuk-button--warning govuk-!-margin-right-1",
+  data: {
+    "module" => "govuk-button"
+  },
+  params: {
+    confirm: true
+  },
+  form: {
+    class: 'govuk-!-display-inline-block'
+  }
+%>
+<%= link_to "Cancel", root_path,
+  class: "govuk-button govuk-button--secondary",
+  data: {
+    module: "govuk-button"
+  }
+%>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2021_07_07_112308) do
-
   create_table "audits", charset: "utf8", force: :cascade do |t|
     t.integer "auditable_id"
     t.string "auditable_type"
@@ -63,5 +62,4 @@ ActiveRecord::Schema.define(version: 2021_07_07_112308) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end
-
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,6 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2021_07_07_112308) do
+
   create_table "audits", charset: "utf8", force: :cascade do |t|
     t.integer "auditable_id"
     t.string "auditable_type"
@@ -62,4 +63,5 @@ ActiveRecord::Schema.define(version: 2021_07_07_112308) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end
+
 end


### PR DESCRIPTION
# What
Allow deleting policies

# Why
So we can delete policies that are no longer needed

