### PR TITLE
Allow updating rules

### DIFF
--- a/app/controllers/rules_controller.rb
+++ b/app/controllers/rules_controller.rb
@@ -1,5 +1,5 @@
 class RulesController < ApplicationController
-  before_action :set_policy, only: [:new, :create, :destroy, :edit]
+  before_action :set_policy, only: [:new, :create, :destroy, :edit, :update]
 
   def new
     @rule = Rule.new
@@ -34,6 +34,19 @@ class RulesController < ApplicationController
   def edit
     @rule = Rule.find(params.fetch(:id))
     authorize! :update, @rule
+  end
+
+  def update
+    @rule = Rule.find(params.fetch(:id))
+    authorize! :update, @rule
+
+    @rule.assign_attributes(rule_params)
+
+    if @rule.save
+      redirect_to policy_path(@policy), notice: "Successfully updated rule. "
+    else
+      render :edit
+    end
   end
 
   private

--- a/app/controllers/rules_controller.rb
+++ b/app/controllers/rules_controller.rb
@@ -1,5 +1,5 @@
 class RulesController < ApplicationController
-  before_action :set_policy, only: [:new, :create, :destroy]
+  before_action :set_policy, only: [:new, :create, :destroy, :edit]
 
   def new
     @rule = Rule.new
@@ -29,6 +29,11 @@ class RulesController < ApplicationController
     else
       render "rules/destroy"
     end
+  end
+
+  def edit
+    @rule = Rule.find(params.fetch(:id))
+    authorize! :update, @rule
   end
 
   private

--- a/app/views/policies/show.html.erb
+++ b/app/views/policies/show.html.erb
@@ -35,6 +35,7 @@
           <td class="govuk-table__cell"><%= rule.value %></td>
           <td class="govuk-table__cell">
             <% if can? :manage, Rule %>
+              <%= link_to "Edit", edit_policy_rule_path(policy_id: @policy, id: rule), class:"govuk-link" %>
               <%= link_to "Delete", policy_rule_path(policy_id: @policy, id: rule), class:"govuk-link", method: :delete %>
             <% end %>
           </td>

--- a/app/views/rules/_form.html.erb
+++ b/app/views/rules/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: rule, url: policy_rules_path(@rule, policy_id: @policy.id), local: true) do |f| %>
+<%= form_with(model: rule, url: path, local: true) do |f| %>
   <div class="govuk-form-group <%= field_error(f.object, :request_attribute) %>">
     <%= f.label :request_attribute, class: "govuk-label" %>
     <%= f.text_field :request_attribute, class: "govuk-input" %>

--- a/app/views/rules/_form.html.erb
+++ b/app/views/rules/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: @rule, url: policy_rules_path(@rule, policy_id: @policy.id), local: true) do |f| %>
+<%= form_with(model: rule, url: policy_rules_path(@rule, policy_id: @policy.id), local: true) do |f| %>
   <div class="govuk-form-group <%= field_error(f.object, :request_attribute) %>">
     <%= f.label :request_attribute, class: "govuk-label" %>
     <%= f.text_field :request_attribute, class: "govuk-input" %>
@@ -19,7 +19,7 @@
     "data-module" => "govuk-button"
   } %>
 
-  <%= link_to "Cancel", f.object.new_record? ? root_path : @rule,
+  <%= link_to "Cancel", policy_path(@policy),
   class: "govuk-button govuk-button--secondary",
   data: {
     module: "govuk-button"

--- a/app/views/rules/edit.html.erb
+++ b/app/views/rules/edit.html.erb
@@ -1,0 +1,5 @@
+<%= render "layouts/form_errors", resource: @rule %>
+
+<h2 class="govuk-heading-l">Editing a rule</h2>
+
+<%= render "rules/form", rule: @rule %>

--- a/app/views/rules/edit.html.erb
+++ b/app/views/rules/edit.html.erb
@@ -2,4 +2,4 @@
 
 <h2 class="govuk-heading-l">Editing a rule</h2>
 
-<%= render "rules/form", rule: @rule %>
+<%= render "rules/form", path: policy_rule_path(policy_id: @policy, id: @rule), rule: @rule %>

--- a/app/views/rules/new.html.erb
+++ b/app/views/rules/new.html.erb
@@ -2,4 +2,4 @@
 
 <h2 class="govuk-heading-l">Create a new rule</h2>
 
-<%= render "rules/form", rule: @rule %>
+<%= render "rules/form", path: policy_rules_path(policy_id: @policy, id: @rule), rule: @rule %>

--- a/spec/acceptance/policy/rules/update_rules_spec.rb
+++ b/spec/acceptance/policy/rules/update_rules_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+
+describe "update rules", type: :feature do
+  let(:policy) do
+    Audited.audit_class.as_user(User.first) do
+      create(:policy)
+    end
+  end
+  let(:rule) { create(:rule, policy: policy) }
+
+  context "when the user is unauthenticated" do
+    it "does not allow updating rules" do
+
+      visit "/policies/#{policy.id}/rules/#{rule.id}/edit"
+
+      expect(page).to have_content "You need to sign in or sign up before continuing."
+    end
+  end
+
+  context "when the user is a viewer" do
+    before do
+      login_as create(:user, :reader)
+    end
+
+    it "does not allow editing rules" do
+      visit "/policies/#{policy.id}"
+
+      expect(page).not_to have_content "Edit"
+
+      visit "/policies/#{policy.id}/rules/#{rule.id}/edit"
+
+      expect(page).to have_content "You are not authorized to access this page."
+    end
+  end
+
+  context "when the user is an editor" do
+    let(:editor) { create(:user, :editor) }
+
+    before do
+      login_as editor
+      rule
+    end
+
+    it "does update an existing rule" do
+      visit "policies/#{policy.id}"
+
+      first(:link, "Edit").click
+
+      expect(page).to have_field("Request attribute", with: rule.request_attribute)
+      expect(page).to have_select("Operator", text: rule.operator)
+      expect(page).to have_field("Value", with: rule.value)
+
+      fill_in "Request attribute", with: "Tunnel-Type"
+      select "contains", from: "Operator"
+      fill_in "Value", with: "LAN"
+
+      click_on "Update"
+
+      expect(current_path).to eq("/policies/#{policy.id}")
+
+      expect(page).to have_content("Successfully updated rule.")
+      expect(page).to have_content "Tunnel-Type"
+      expect(page).to have_content "contains"
+      expect(page).to have_content "LAN"
+
+      expect_audit_log_entry_for(editor.email, "update", "Rule")
+    end
+  end
+end

--- a/spec/acceptance/policy/rules/update_rules_spec.rb
+++ b/spec/acceptance/policy/rules/update_rules_spec.rb
@@ -10,7 +10,6 @@ describe "update rules", type: :feature do
 
   context "when the user is unauthenticated" do
     it "does not allow updating rules" do
-
       visit "/policies/#{policy.id}/rules/#{rule.id}/edit"
 
       expect(page).to have_content "You need to sign in or sign up before continuing."

--- a/spec/acceptance/policy/update_policies_spec.rb
+++ b/spec/acceptance/policy/update_policies_spec.rb
@@ -7,8 +7,8 @@ describe "update policies", type: :feature do
     end
   end
 
-  context "when the user is a unauthenticated" do
-    it "does not allow creating policies" do
+  context "when the user is unauthenticated" do
+    it "does not allow updating policies" do
       visit "/policies/#{policy.to_param}/edit"
 
       expect(page).to have_content "You need to sign in or sign up before continuing."
@@ -23,7 +23,7 @@ describe "update policies", type: :feature do
     it "does not allow editing policies" do
       visit "/policies"
 
-      expect(page).not_to have_content "Edit"
+      expect(page).not_to have_content "Change"
 
       visit "/policies/#{policy.to_param}/edit"
 
@@ -39,7 +39,7 @@ describe "update policies", type: :feature do
       policy
     end
 
-    it "update an existing policy" do
+    it "does update an existing policy" do
       visit "/policies/#{policy.id}"
 
       first(:link, "Change").click


### PR DESCRIPTION
# What
Complete the user journey of updating an existing rule

# Why
To allow users to update a rule attached to an existing policy
