### PR TITLE
Add editing of responses attached to policies

### DIFF
--- a/app/controllers/responses_controller.rb
+++ b/app/controllers/responses_controller.rb
@@ -1,5 +1,5 @@
 class ResponsesController < ApplicationController
-  before_action :set_policy, only: [:new, :create, :destroy]
+  before_action :set_policy, only: [:new, :create, :destroy, :edit, :update]
 
   def new
     @response = Response.new
@@ -28,6 +28,24 @@ class ResponsesController < ApplicationController
       end
     else
       render "responses/destroy"
+    end
+  end
+
+  def edit
+    @response = Response.find(params.fetch(:id))
+    authorize! :update, @response
+  end
+
+  def update
+    @response = Response.find(params.fetch(:id))
+    authorize! :update, @response
+
+    @response.assign_attributes(response_params)
+
+    if @response.save
+      redirect_to policy_path(@policy), notice: "Successfully updated response. "
+    else
+      render :edit
     end
   end
 

--- a/app/views/policies/_form.html.erb
+++ b/app/views/policies/_form.html.erb
@@ -14,7 +14,7 @@
     "data-module" => "govuk-button"
   } %>
 
-  <%= link_to "Cancel", f.object.new_record? ? root_path : policy,
+  <%= link_to "Cancel", f.object.new_record? ? policies_path : policy,
   class: "govuk-button govuk-button--secondary",
   data: {
     module: "govuk-button"

--- a/app/views/policies/show.html.erb
+++ b/app/views/policies/show.html.erb
@@ -66,6 +66,7 @@
           <td class="govuk-table__cell"><%= response.value %></td>
           <td class="govuk-table__cell">
             <% if can? :manage, Response %>
+              <%= link_to "Edit", edit_policy_response_path(policy_id: @policy, id: response), class:"govuk-link" %>
               <%= link_to "Delete", policy_response_path(policy_id: @policy, id: response), class:"govuk-link", method: :delete %>
             <% end %>
           </td>

--- a/app/views/responses/edit.html.erb
+++ b/app/views/responses/edit.html.erb
@@ -1,0 +1,5 @@
+<%= render "layouts/form_errors", resource: @response %>
+
+<h2 class="govuk-heading-l">Editing a response</h2>
+
+<%= render "responses/form", path: policy_response_path(policy_id: @policy, id: @response), response: @response %>

--- a/spec/acceptance/policy/responses/update_responses_spec.rb
+++ b/spec/acceptance/policy/responses/update_responses_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+describe "update responses", type: :feature do
+  let(:policy) { create(:policy) }
+  let(:response) { create(:response, policy: policy) }
+
+  context "when the user is unauthenticated" do
+    it "does not allow updating responses" do
+      visit "/policies/#{policy.id}/responses/#{response.id}/edit"
+
+      expect(page).to have_content "You need to sign in or sign up before continuing."
+    end
+  end
+
+  context "when the user is a viewer" do
+    before do
+      login_as create(:user, :reader)
+    end
+
+    it "does not allow editing responses" do
+      visit "/policies/#{policy.id}"
+
+      expect(page).not_to have_content "Edit"
+
+      visit "/policies/#{policy.id}/responses/#{response.id}/edit"
+
+      expect(page).to have_content "You are not authorized to access this page."
+    end
+  end
+
+  context "when the user is an editor" do
+    let(:editor) { create(:user, :editor) }
+
+    before do
+      login_as editor
+      response
+    end
+
+    it "does update an existing response" do
+      visit "policies/#{policy.id}"
+
+      first(:link, "Edit").click
+
+      expect(page).to have_field("Response attribute", with: response.response_attribute)
+      expect(page).to have_field("Value", with: response.value)
+
+      fill_in "Response attribute", with: "Updated VLAN ID"
+      fill_in "Value", with: "5678"
+
+      click_on "Update"
+
+      expect(current_path).to eq("/policies/#{policy.id}")
+
+      expect(page).to have_content("Successfully updated response.")
+      expect(page).to have_content "Updated VLAN ID"
+      expect(page).to have_content "5678"
+
+      expect_audit_log_entry_for(editor.email, "update", "Response")
+    end
+  end
+end


### PR DESCRIPTION
# What

- Add editing of responses attached to policies

# Why

- To be able to edit and update responses
