### PR TITLE
Add database migration for MAC authentication bypasses

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -373,6 +373,7 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
+  x86_64-darwin-19
   x86_64-darwin-20
   x86_64-linux
 

--- a/app/models/mac_authentication_bypass.rb
+++ b/app/models/mac_authentication_bypass.rb
@@ -1,0 +1,5 @@
+class MacAuthenticationBypass < ApplicationRecord
+  validates :address, presence: true, uniqueness: true
+
+  audited
+end

--- a/db/migrate/20210715110757_create_mac_authentication_bypasses.rb
+++ b/db/migrate/20210715110757_create_mac_authentication_bypasses.rb
@@ -1,0 +1,11 @@
+class CreateMacAuthenticationBypasses < ActiveRecord::Migration[6.1]
+  def change
+    create_table :mac_authentication_bypasses do |t|
+      t.string :address, null: false, unique: true
+      t.string :name
+      t.text :description
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,78 +10,87 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_210_712_094_005) do
-  create_table 'audits', charset: 'utf8', force: :cascade do |t|
-    t.integer 'auditable_id'
-    t.string 'auditable_type'
-    t.integer 'associated_id'
-    t.string 'associated_type'
-    t.integer 'user_id'
-    t.string 'user_type'
-    t.string 'username'
-    t.string 'action'
-    t.json 'audited_changes'
-    t.integer 'version', default: 0
-    t.string 'comment'
-    t.string 'remote_address'
-    t.string 'request_uuid'
-    t.datetime 'created_at'
-    t.index %w[associated_type associated_id], name: 'associated_index'
-    t.index %w[auditable_type auditable_id version], name: 'auditable_index'
-    t.index ['created_at'], name: 'index_audits_on_created_at'
-    t.index ['request_uuid'], name: 'index_audits_on_request_uuid'
-    t.index %w[user_id user_type], name: 'user_index'
+ActiveRecord::Schema.define(version: 2021_07_15_110757) do
+
+  create_table "audits", charset: "utf8", force: :cascade do |t|
+    t.integer "auditable_id"
+    t.string "auditable_type"
+    t.integer "associated_id"
+    t.string "associated_type"
+    t.integer "user_id"
+    t.string "user_type"
+    t.string "username"
+    t.string "action"
+    t.json "audited_changes"
+    t.integer "version", default: 0
+    t.string "comment"
+    t.string "remote_address"
+    t.string "request_uuid"
+    t.datetime "created_at"
+    t.index ["associated_type", "associated_id"], name: "associated_index"
+    t.index ["auditable_type", "auditable_id", "version"], name: "auditable_index"
+    t.index ["created_at"], name: "index_audits_on_created_at"
+    t.index ["request_uuid"], name: "index_audits_on_request_uuid"
+    t.index ["user_id", "user_type"], name: "user_index"
   end
 
-  create_table 'policies', charset: 'utf8', force: :cascade do |t|
-    t.string 'name', null: false
-    t.text 'description', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
+  create_table "mac_authentication_bypasses", charset: "utf8", force: :cascade do |t|
+    t.string "address", null: false
+    t.string "name"
+    t.text "description"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
-  create_table 'responses', charset: 'utf8', force: :cascade do |t|
-    t.bigint 'policy_id', null: false
-    t.string 'response_attribute', null: false
-    t.string 'value', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index ['policy_id'], name: 'index_responses_on_policy_id'
+  create_table "policies", charset: "utf8", force: :cascade do |t|
+    t.string "name", null: false
+    t.text "description", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
-  create_table 'rules', charset: 'utf8', force: :cascade do |t|
-    t.string 'operator', null: false
-    t.string 'value', null: false
-    t.bigint 'policy_id', null: false
-    t.string 'request_attribute', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index ['policy_id'], name: 'index_rules_on_policy_id'
+  create_table "responses", charset: "utf8", force: :cascade do |t|
+    t.bigint "policy_id", null: false
+    t.string "response_attribute", null: false
+    t.string "value", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["policy_id"], name: "index_responses_on_policy_id"
   end
 
-  create_table 'sites', charset: 'utf8', force: :cascade do |t|
-    t.string 'name', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
+  create_table "rules", charset: "utf8", force: :cascade do |t|
+    t.string "operator", null: false
+    t.string "value", null: false
+    t.bigint "policy_id", null: false
+    t.string "request_attribute", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["policy_id"], name: "index_rules_on_policy_id"
   end
 
-  create_table 'users', charset: 'utf8', force: :cascade do |t|
-    t.string 'provider'
-    t.string 'uid'
-    t.boolean 'editor', default: false
-    t.string 'email'
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
+  create_table "sites", charset: "utf8", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
-  create_table 'vlans', charset: 'utf8', force: :cascade do |t|
-    t.integer 'vlan', null: false
-    t.string 'common_name', null: false
-    t.string 'remote_ip', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
+  create_table "users", charset: "utf8", force: :cascade do |t|
+    t.string "provider"
+    t.string "uid"
+    t.boolean "editor", default: false
+    t.string "email"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
-  add_foreign_key 'responses', 'policies'
-  add_foreign_key 'rules', 'policies'
+  create_table "vlans", charset: "utf8", force: :cascade do |t|
+    t.integer "vlan", null: false
+    t.string "common_name", null: false
+    t.string "remote_ip", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  add_foreign_key "responses", "policies"
+  add_foreign_key "rules", "policies"
 end

--- a/spec/models/mac_authentication_bypass_spec.rb
+++ b/spec/models/mac_authentication_bypass_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+describe MacAuthenticationBypass, type: :model do
+  subject { build :mac_authentication_bypass }
+
+  it "has a valid bypass" do
+    expect(subject).to be_valid
+  end
+
+  it { is_expected.to validate_presence_of :address }
+  it { is_expected.to validate_uniqueness_of(:address).case_insensitive }
+end


### PR DESCRIPTION
# What

- Add database migration to create a table for MAC authentication bypasses
- Add model for MAC authentication bypasses

# Why

- To be able to store all of the MAC addresses that need to be given access to the network
