### PR TITLE
Add MAC authentication bypasses interface

### DIFF
--- a/app/controllers/mac_authentication_bypasses_controller.rb
+++ b/app/controllers/mac_authentication_bypasses_controller.rb
@@ -1,0 +1,5 @@
+class MacAuthenticationBypassesController < ApplicationController
+  def index
+    @mac_authentication_bypasses = MacAuthenticationBypass.all
+  end
+end

--- a/app/controllers/mac_authentication_bypasses_controller.rb
+++ b/app/controllers/mac_authentication_bypasses_controller.rb
@@ -1,5 +1,5 @@
 class MacAuthenticationBypassesController < ApplicationController
-  before_action :set_mac_authentication_bypass, only: :destroy
+  before_action :set_mac_authentication_bypass, only: %i[destroy edit update]
 
   def index
     @mac_authentication_bypasses = MacAuthenticationBypass.all
@@ -32,6 +32,21 @@ class MacAuthenticationBypassesController < ApplicationController
       end
     else
       render "mac_authentication_bypasses/destroy"
+    end
+  end
+
+  def edit
+    authorize! :update, @mac_authentication_bypass
+  end
+
+  def update
+    authorize! :update, @mac_authentication_bypass
+    @mac_authentication_bypass.assign_attributes(mac_authentication_bypass_params)
+
+    if @mac_authentication_bypass.save
+      redirect_to mac_authentication_bypasses_path, notice: "Successfully updated MAC authentication bypass. "
+    else
+      render :edit
     end
   end
 

--- a/app/controllers/mac_authentication_bypasses_controller.rb
+++ b/app/controllers/mac_authentication_bypasses_controller.rb
@@ -2,4 +2,27 @@ class MacAuthenticationBypassesController < ApplicationController
   def index
     @mac_authentication_bypasses = MacAuthenticationBypass.all
   end
+
+  def new
+    @mac_authentication_bypass = MacAuthenticationBypass.new
+
+    authorize! :create, @mac_authentication_bypass
+  end
+
+  def create
+    @mac_authentication_bypass = MacAuthenticationBypass.new(mac_authentication_bypass_params)
+    authorize! :create, @mac_authentication_bypass
+
+    if @mac_authentication_bypass.save
+      redirect_to mac_authentication_bypasses_path, notice: "Successfully created MAC authentication bypass. "
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def mac_authentication_bypass_params
+    params.require(:mac_authentication_bypass).permit(:address, :name, :description)
+  end
 end

--- a/app/controllers/mac_authentication_bypasses_controller.rb
+++ b/app/controllers/mac_authentication_bypasses_controller.rb
@@ -1,4 +1,6 @@
 class MacAuthenticationBypassesController < ApplicationController
+  before_action :set_mac_authentication_bypass, only: :destroy
+
   def index
     @mac_authentication_bypasses = MacAuthenticationBypass.all
   end
@@ -20,9 +22,34 @@ class MacAuthenticationBypassesController < ApplicationController
     end
   end
 
+  def destroy
+    authorize! :destroy, @mac_authentication_bypass
+    if confirmed?
+      if @mac_authentication_bypass.destroy
+        redirect_to mac_authentication_bypasses_path, notice: "Successfully deleted MAC authentication bypass. "
+      else
+        redirect_to mac_authentication_bypasses_path, error: "Failed to delete the MAC authentication bypass"
+      end
+    else
+      render "mac_authentication_bypasses/destroy"
+    end
+  end
+
   private
 
   def mac_authentication_bypass_params
     params.require(:mac_authentication_bypass).permit(:address, :name, :description)
+  end
+
+  def mac_authentication_bypass_id
+    params.fetch(:id)
+  end
+
+  def set_mac_authentication_bypass
+    @mac_authentication_bypass = MacAuthenticationBypass.find(mac_authentication_bypass_id)
+  end
+
+  def confirmed?
+    params.fetch(:confirm, false)
   end
 end

--- a/app/controllers/mac_authentication_bypasses_controller.rb
+++ b/app/controllers/mac_authentication_bypasses_controller.rb
@@ -50,7 +50,7 @@ class MacAuthenticationBypassesController < ApplicationController
     end
   end
 
-  private
+private
 
   def mac_authentication_bypass_params
     params.require(:mac_authentication_bypass).permit(:address, :name, :description)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -2,8 +2,8 @@ class Ability
   include CanCan::Ability
 
   def initialize(user)
-    can :read, [Policy, Site, Rule, Response]
+    can :read, [Policy, Site, Rule, Response, MacAuthenticationBypass]
 
-    can :manage, [Policy, Site, Rule, Response] if user.editor?
+    can :manage, [Policy, Site, Rule, Response, MacAuthenticationBypass] if user.editor?
   end
 end

--- a/app/presenters/mac_authentication_bypass_presenter.rb
+++ b/app/presenters/mac_authentication_bypass_presenter.rb
@@ -1,0 +1,5 @@
+class MacAuthenticationBypassPresenter < BasePresenter
+  def display_name
+    "#{record.address} #{record.name} #{record.description}"
+  end
+end

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -9,6 +9,10 @@
         <%= link_to "Policies", policies_path, class: "govuk-header__link" %>
       </li>
 
+      <li class="govuk-header__navigation-item<%= selected_class_if_controller('mac_authentication_bypasses') %>">
+        <%= link_to "MAB", mac_authentication_bypasses_path, class: "govuk-header__link" %>
+      </li>
+
       <li class="govuk-header__navigation-item<%= selected_class_if_controller('audit_log') %>">
         <%= link_to "Audit log", audits_path, class: "govuk-header__link" %>
       </li>

--- a/app/views/mac_authentication_bypasses/_form.html.erb
+++ b/app/views/mac_authentication_bypasses/_form.html.erb
@@ -1,0 +1,29 @@
+<%= form_with model: mac_authentication_bypass, local: true do |f| %>
+  <div class="govuk-form-group <%= field_error(f.object, :address) %>">
+    <%= f.label :address, class: "govuk-label" %>
+    <%= f.text_field :address, class: "govuk-input" %>
+  </div>
+
+  <div class="govuk-form-group <%= field_error(f.object, :name) %>">
+    <%= f.label :name, class: "govuk-label" %>
+    <%= f.text_field :name, class: "govuk-input" %>
+  </div>
+
+  <div class="govuk-form-group <%= field_error(f.object, :description) %>">
+    <%= f.label :description, class: "govuk-label" %>
+    <%= f.text_area :description, class: "govuk-input" %>
+  </div>
+
+  <%= f.submit f.object.new_record? ? "Create" : "Update", {
+    class: "govuk-button",
+    "data-module" => "govuk-button"
+  } %>
+
+  <%= link_to "Cancel", f.object.new_record? ? mac_authentication_bypasses_path : mac_authentication_bypass,
+  class: "govuk-button govuk-button--secondary",
+  data: {
+    module: "govuk-button"
+  }
+%>
+
+<% end %>

--- a/app/views/mac_authentication_bypasses/destroy.html.erb
+++ b/app/views/mac_authentication_bypasses/destroy.html.erb
@@ -1,0 +1,36 @@
+<h2 class="govuk-heading-l">Are you sure you want to delete this MAC authentication bypass?</h2>
+
+<div class="govuk-inset-text">
+  <h4 class="govuk-heading-s">MAC authentication bypass:</h4>
+  <p class="govuk-body"><%= @mac_authentication_bypass.address %></p>
+  <p class="govuk-body"><%= @mac_authentication_bypass.name %></p>
+  <p class="govuk-body"><%= @mac_authentication_bypass.description %></p>
+</div>
+
+<div class="govuk-warning-text">
+  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+  <strong class="govuk-warning-text__text">
+    <span class="govuk-warning-text__assistive">Warning</span>
+      Deleting a MAC authentication bypass cannot be undone.
+  </strong>
+</div>
+
+<%= button_to "Delete bypass", mac_authentication_bypass_path(@mac_authentication_bypass),
+  method: :delete,
+  class: "govuk-button govuk-button--warning govuk-!-margin-right-1",
+  data: {
+    "module" => "govuk-button"
+  },
+  params: {
+    confirm: true
+  },
+  form: {
+    class: 'govuk-!-display-inline-block'
+  }
+%>
+<%= link_to "Cancel", mac_authentication_bypasses_path,
+  class: "govuk-button govuk-button--secondary",
+  data: {
+    module: "govuk-button"
+  }
+%>

--- a/app/views/mac_authentication_bypasses/destroy.html.erb
+++ b/app/views/mac_authentication_bypasses/destroy.html.erb
@@ -1,10 +1,15 @@
 <h2 class="govuk-heading-l">Are you sure you want to delete this MAC authentication bypass?</h2>
 
 <div class="govuk-inset-text">
-  <h4 class="govuk-heading-s">MAC authentication bypass:</h4>
-  <p class="govuk-body"><%= @mac_authentication_bypass.address %></p>
-  <p class="govuk-body"><%= @mac_authentication_bypass.name %></p>
-  <p class="govuk-body"><%= @mac_authentication_bypass.description %></p>
+  <p class="govuk-body">
+    <span class="govuk-!-font-weight-bold">MAC Address:</span> <%= @mac_authentication_bypass.address %>
+  </p>
+  <p class="govuk-body">
+    <span class="govuk-!-font-weight-bold">Name:</span> <%= @mac_authentication_bypass.name %>
+  </p>
+  <p class="govuk-body">
+    <span class="govuk-!-font-weight-bold">Description:</span> <%= @mac_authentication_bypass.description %>
+  </p>
 </div>
 
 <div class="govuk-warning-text">

--- a/app/views/mac_authentication_bypasses/edit.html.erb
+++ b/app/views/mac_authentication_bypasses/edit.html.erb
@@ -1,0 +1,5 @@
+<%= render "layouts/form_errors", resource: @mac_authentication_bypass %>
+
+<h2 class="govuk-heading-l">Editing a bypass</h2>
+
+<%= render "mac_authentication_bypasses/form", mac_authentication_bypass: @mac_authentication_bypass %>

--- a/app/views/mac_authentication_bypasses/index.html.erb
+++ b/app/views/mac_authentication_bypasses/index.html.erb
@@ -1,0 +1,23 @@
+<div>
+  <h2 class="govuk-heading-l">MAC Authentication Bypasses</h2>
+
+  <table class="govuk-table">
+    <caption class="govuk-table__caption">List of MAC Authentication Bypasses</caption>
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header">Address</th>
+        <th scope="col" class="govuk-table__header">Name</th>
+        <th scope="col" class="govuk-table__header">Description</th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+      <% @mac_authentication_bypasses.each do |bypass| %>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell"><%= bypass.address %></td>
+          <td class="govuk-table__cell"><%= bypass.name %></td>
+          <td class="govuk-table__cell"><%= bypass.description %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/mac_authentication_bypasses/index.html.erb
+++ b/app/views/mac_authentication_bypasses/index.html.erb
@@ -23,10 +23,12 @@
           <td class="govuk-table__cell"><%= bypass.address %></td>
           <td class="govuk-table__cell"><%= bypass.name %></td>
           <td class="govuk-table__cell"><%= bypass.description %></td>
-          <% if can? :manage, MacAuthenticationBypass %>
-            <%= link_to "Change", edit_mac_authentication_bypass_path(bypass), class:"govuk-link" %>
-            <%= link_to "Delete", mac_authentication_bypass_path(bypass), class:"govuk-link", method: :delete %>
-          <% end %>
+          <td class="govuk-table__cell">
+            <% if can? :manage, MacAuthenticationBypass %>
+              <%= link_to "Change", edit_mac_authentication_bypass_path(bypass), class:"govuk-link" %>
+              <%= link_to "Delete", mac_authentication_bypass_path(bypass), class:"govuk-link", method: :delete %>
+            <% end %>
+          </td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/mac_authentication_bypasses/index.html.erb
+++ b/app/views/mac_authentication_bypasses/index.html.erb
@@ -24,6 +24,7 @@
           <td class="govuk-table__cell"><%= bypass.name %></td>
           <td class="govuk-table__cell"><%= bypass.description %></td>
           <% if can? :manage, MacAuthenticationBypass %>
+            <%= link_to "Change", edit_mac_authentication_bypass_path(bypass), class:"govuk-link" %>
             <%= link_to "Delete", mac_authentication_bypass_path(bypass), class:"govuk-link", method: :delete %>
           <% end %>
         </tr>

--- a/app/views/mac_authentication_bypasses/index.html.erb
+++ b/app/views/mac_authentication_bypasses/index.html.erb
@@ -1,6 +1,10 @@
 <div>
   <h2 class="govuk-heading-l">MAC Authentication Bypasses</h2>
 
+  <% if can? :create, MacAuthenticationBypass %>
+    <%= link_to "Create a new bypass", new_mac_authentication_bypass_path, class: "govuk-button" %>
+  <% end %>
+
   <table class="govuk-table">
     <caption class="govuk-table__caption">List of MAC Authentication Bypasses</caption>
     <thead class="govuk-table__head">

--- a/app/views/mac_authentication_bypasses/index.html.erb
+++ b/app/views/mac_authentication_bypasses/index.html.erb
@@ -12,6 +12,9 @@
         <th scope="col" class="govuk-table__header">Address</th>
         <th scope="col" class="govuk-table__header">Name</th>
         <th scope="col" class="govuk-table__header">Description</th>
+        <th scope="col" class="govuk-table__header">
+          <span class="govuk-visually-hidden">Actions</span>
+        </th>
       </tr>
     </thead>
     <tbody class="govuk-table__body">
@@ -20,6 +23,9 @@
           <td class="govuk-table__cell"><%= bypass.address %></td>
           <td class="govuk-table__cell"><%= bypass.name %></td>
           <td class="govuk-table__cell"><%= bypass.description %></td>
+          <% if can? :manage, MacAuthenticationBypass %>
+            <%= link_to "Delete", mac_authentication_bypass_path(bypass), class:"govuk-link", method: :delete %>
+          <% end %>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/mac_authentication_bypasses/index.html.erb
+++ b/app/views/mac_authentication_bypasses/index.html.erb
@@ -6,7 +6,7 @@
   <% end %>
 
   <table class="govuk-table">
-    <caption class="govuk-table__caption">List of MAC Authentication Bypasses</caption>
+    <caption class="govuk-table__caption govuk-visually-hidden">List of MAC Authentication Bypasses</caption>
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th scope="col" class="govuk-table__header">Address</th>

--- a/app/views/mac_authentication_bypasses/new.html.erb
+++ b/app/views/mac_authentication_bypasses/new.html.erb
@@ -1,0 +1,5 @@
+<%= render "layouts/form_errors", resource: @mac_authentication_bypass %>
+
+<h2 class="govuk-heading-l">Create a new bypass</h2>
+
+<%= render "mac_authentication_bypasses/form", mac_authentication_bypass: @mac_authentication_bypass %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
     match "sign_out", to: "devise/sessions#destroy", as: :destroy_user_session, via: %i[get delete]
   end
 
+  resources :mac_authentication_bypasses, only: :index
   resources :sites, :vlans
   resources :policies do
     resources :rules

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
     match "sign_out", to: "devise/sessions#destroy", as: :destroy_user_session, via: %i[get delete]
   end
 
-  resources :mac_authentication_bypasses, only: %i[index new create]
+  resources :mac_authentication_bypasses, only: %i[index new create destroy]
   resources :sites, :vlans
   resources :policies do
     resources :rules

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
     match "sign_out", to: "devise/sessions#destroy", as: :destroy_user_session, via: %i[get delete]
   end
 
-  resources :mac_authentication_bypasses, only: %i[index new create destroy edit update]
+  resources :mac_authentication_bypasses, except: :show
   resources :sites, :vlans
   resources :policies do
     resources :rules

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
     match "sign_out", to: "devise/sessions#destroy", as: :destroy_user_session, via: %i[get delete]
   end
 
-  resources :mac_authentication_bypasses, only: :index
+  resources :mac_authentication_bypasses, only: %i[index new create]
   resources :sites, :vlans
   resources :policies do
     resources :rules

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
     match "sign_out", to: "devise/sessions#destroy", as: :destroy_user_session, via: %i[get delete]
   end
 
-  resources :mac_authentication_bypasses, only: %i[index new create destroy]
+  resources :mac_authentication_bypasses, only: %i[index new create destroy edit update]
   resources :sites, :vlans
   resources :policies do
     resources :rules

--- a/spec/acceptance/mac_authentication_bypass/create_spec.rb
+++ b/spec/acceptance/mac_authentication_bypass/create_spec.rb
@@ -1,0 +1,62 @@
+require "rails_helper"
+
+describe "create MAC Authentication Bypasses", type: :feature do
+  context "when the user is unauthenticated" do
+    it "does not allow creating bypasses" do
+      visit "/mac_authentication_bypasses/new"
+
+      expect(page).to have_content "You need to sign in or sign up before continuing."
+    end
+  end
+
+  context "when the user is a viewer" do
+    before do
+      login_as create(:user, :reader)
+    end
+
+    it "does not allow creating bypasses" do
+      visit "/mac_authentication_bypasses"
+
+      expect(page).not_to have_content "Create a new MAC authentication bypass"
+
+      visit "/mac_authentication_bypasses/new"
+
+      expect(page).to have_content "You are not authorized to access this page."
+    end
+  end
+
+  context "when the user is an editor" do
+    let(:editor) { create(:user, :editor) }
+
+    before do
+      login_as editor
+    end
+
+    it "creates a new bypass" do
+      visit "/mac_authentication_bypasses"
+
+      click_on "Create a new bypass"
+
+      expect(current_path).to eql("/mac_authentication_bypasses/new")
+
+      fill_in "Address", with: "00:11:22:33:55"
+      fill_in "Name", with: "CCTV"
+      fill_in "Description", with: "This is a test bypass"
+
+      click_on "Create"
+
+      expect(page).to have_content("Successfully created MAC authentication bypass.")
+      expect(page).to have_content("00:11:22:33:55")
+
+      expect_audit_log_entry_for(editor.email, "create", "Mac authentication bypass")
+    end
+
+    it "displays error if form cannot be submitted" do
+      visit "/mac_authentication_bypasses/new"
+
+      click_on "Create"
+
+      expect(page).to have_content "There is a problem"
+    end
+  end
+end

--- a/spec/acceptance/mac_authentication_bypass/delete_spec.rb
+++ b/spec/acceptance/mac_authentication_bypass/delete_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+describe "delete MAC authentication bypasses", type: :feature do
+  context "when the user is a viewer" do
+    before do
+      login_as create(:user, :reader)
+    end
+
+    it "does not allow deleting bypasses" do
+      visit "/mac_authentication_bypasses"
+
+      expect(page).not_to have_content "Delete"
+    end
+  end
+
+  context "when the user is an editor" do
+    let!(:mac_authentication_bypass) do
+      create(:mac_authentication_bypass)
+    end
+
+    let(:editor) { create(:user, :editor) }
+
+    before do
+      login_as editor
+    end
+
+    it "does delete a policy" do
+      visit "/mac_authentication_bypasses"
+
+      click_on "Delete"
+
+      expect(page).to have_content("Are you sure you want to delete this MAC authentication bypass?")
+      expect(page).to have_content(mac_authentication_bypass.address)
+      expect(page).to have_content(mac_authentication_bypass.name)
+      expect(page).to have_content(mac_authentication_bypass.description)
+
+      click_on "Delete bypass"
+
+      expect(current_path).to eq("/mac_authentication_bypasses")
+      expect(page).to have_content("Successfully deleted MAC authentication bypass.")
+      expect(page).not_to have_content(mac_authentication_bypass.address)
+
+      expect_audit_log_entry_for(editor.email, "destroy", "Mac authentication bypass")
+    end
+  end
+end

--- a/spec/acceptance/mac_authentication_bypass/update_spec.rb
+++ b/spec/acceptance/mac_authentication_bypass/update_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+describe "update MAC authentication bypasses", type: :feature do
+  let!(:mac_authentication_bypass) do
+    create(:mac_authentication_bypass)
+  end
+
+  context "when the user is unauthenticated" do
+    it "does not allow updating bypasses" do
+      visit "/mac_authentication_bypasses/#{mac_authentication_bypass.to_param}/edit"
+
+      expect(page).to have_content "You need to sign in or sign up before continuing."
+    end
+  end
+
+  context "when the user is a viewer" do
+    before do
+      login_as create(:user, :reader)
+    end
+
+    it "does not allow editing bypasses" do
+      visit "/mac_authentication_bypasses"
+
+      expect(page).not_to have_content "Change"
+
+      visit "/mac_authentication_bypasses/#{mac_authentication_bypass.to_param}/edit"
+
+      expect(page).to have_content "You are not authorized to access this page."
+    end
+  end
+
+  context "when the user is an editor" do
+    let(:editor) { create(:user, :editor) }
+
+    before do
+      login_as editor
+    end
+
+    it "does update an existing bypass" do
+      visit "/mac_authentication_bypasses"
+
+      first(:link, "Change").click
+
+      expect(page).to have_field("Address", with: mac_authentication_bypass.address)
+      expect(page).to have_field("Name", with: mac_authentication_bypass.name)
+      expect(page).to have_field("Description", with: mac_authentication_bypass.description)
+
+      fill_in "Address", with: "55:44:33:22:11"
+
+      click_on "Update"
+
+      expect(current_path).to eq("/mac_authentication_bypasses")
+
+      expect(page).to have_content("55:44:33:22:11")
+      expect(page).to have_content("Successfully updated MAC authentication bypass.")
+
+      expect_audit_log_entry_for(editor.email, "update", "Mac authentication bypass")
+    end
+  end
+end

--- a/spec/acceptance/mac_authentication_bypass/view_spec.rb
+++ b/spec/acceptance/mac_authentication_bypass/view_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+describe "showing a MAC authentication bypass", type: :feature do
+  context "when the user is unauthenticated" do
+    it "does not allow viewing bypasses" do
+      visit "/mac_authentication_bypasses"
+
+      expect(page).to have_content "You need to sign in or sign up before continuing."
+    end
+  end
+
+  context "when the user is authenticated" do
+    before do
+      login_as create(:user, :reader)
+    end
+
+    context "when the MAC authentication bypass exists" do
+      let!(:mac_authentication_bypass) { create :mac_authentication_bypass }
+
+      it "allows viewing bypasses" do
+        visit "/mac_authentication_bypasses"
+
+        expect(page).to have_content mac_authentication_bypass.address
+        expect(page).to have_content mac_authentication_bypass.name
+        expect(page).to have_content mac_authentication_bypass.description
+      end
+    end
+  end
+end


### PR DESCRIPTION
# What

- Add CRUD interface for MAC authentication bypasses (MAB)
- Add menu item for MAB

# Why

- To be able to create, read, update, and delete MAC authentication bypasses