### PR TITLE
Generate authorised_macs file for FreeRadius

### DIFF
--- a/app/lib/use_cases/generate_authorised_clients.rb
+++ b/app/lib/use_cases/generate_authorised_clients.rb
@@ -1,7 +1,5 @@
 class UseCases::GenerateAuthorisedClients
   def call(mac_authentication_bypasses:)
-    mac_authentication_bypasses.map { |mab|
-      mab.address
-    }.join("\n")
+    mac_authentication_bypasses.map(&:address).join("\n")
   end
 end

--- a/app/lib/use_cases/generate_authorised_clients.rb
+++ b/app/lib/use_cases/generate_authorised_clients.rb
@@ -1,7 +1,7 @@
 class UseCases::GenerateAuthorisedClients
   def call(mac_authentication_bypasses:)
-    mac_authentication_bypasses.map do |mab|
+    mac_authentication_bypasses.map { |mab|
       mab.address
-    end.join("\n")
+    }.join("\n")
   end
 end

--- a/app/lib/use_cases/generate_authorised_clients.rb
+++ b/app/lib/use_cases/generate_authorised_clients.rb
@@ -1,0 +1,7 @@
+class UseCases::GenerateAuthorisedClients
+  def call(mac_authentication_bypasses:)
+    mac_authentication_bypasses.map do |mab|
+      mab.address
+    end.join("\n")
+  end
+end

--- a/app/models/mac_authentication_bypass.rb
+++ b/app/models/mac_authentication_bypass.rb
@@ -1,5 +1,6 @@
 class MacAuthenticationBypass < ApplicationRecord
   validates :address, presence: true, uniqueness: true
+  validates_format_of :address, with: /\A([0-9a-f]{2}[-]){5}([0-9a-f]{2})\z/, on: :create
 
   audited
 end

--- a/app/models/mac_authentication_bypass.rb
+++ b/app/models/mac_authentication_bypass.rb
@@ -1,6 +1,6 @@
 class MacAuthenticationBypass < ApplicationRecord
   validates :address, presence: true, uniqueness: true
-  validates_format_of :address, with: /\A([0-9a-f]{2}[-]){5}([0-9a-f]{2})\z/, on: :create
+  validates_format_of :address, with: /\A([0-9a-f]{2}-){5}([0-9a-f]{2})\z/, on: :create
 
   audited
 end

--- a/app/views/mac_authentication_bypasses/_form.html.erb
+++ b/app/views/mac_authentication_bypasses/_form.html.erb
@@ -1,6 +1,10 @@
 <%= form_with model: mac_authentication_bypass, local: true do |f| %>
   <div class="govuk-form-group <%= field_error(f.object, :address) %>">
     <%= f.label :address, class: "govuk-label" %>
+    <div id="address-hint" class="govuk-hint">
+      Must be lowercase and separated by a dash.<br />
+      For example: aa-bb-cc-77-88-99
+    </div>
     <%= f.text_field :address, class: "govuk-input" %>
   </div>
 

--- a/spec/acceptance/mac_authentication_bypass/create_spec.rb
+++ b/spec/acceptance/mac_authentication_bypass/create_spec.rb
@@ -39,14 +39,14 @@ describe "create MAC Authentication Bypasses", type: :feature do
 
       expect(current_path).to eql("/mac_authentication_bypasses/new")
 
-      fill_in "Address", with: "00:11:22:33:55"
+      fill_in "Address", with: "00-11-22-33-55-66"
       fill_in "Name", with: "CCTV"
       fill_in "Description", with: "This is a test bypass"
 
       click_on "Create"
 
       expect(page).to have_content("Successfully created MAC authentication bypass.")
-      expect(page).to have_content("00:11:22:33:55")
+      expect(page).to have_content("00-11-22-33-55-66")
 
       expect_audit_log_entry_for(editor.email, "create", "Mac authentication bypass")
     end

--- a/spec/factories/mac_authentication_bypass.rb
+++ b/spec/factories/mac_authentication_bypass.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :mac_authentication_bypass do
-    sequence(:address) { |n| "00:11:22:33:4#{n}" }
+    sequence(:address) { |n| "aa-11-22-33-44-#{n}#{n}" }
     sequence(:name) { |n| "Printer #{n}" }
     sequence(:description) { |n| "Printer description #{n}" }
   end

--- a/spec/models/mac_authentication_bypass_spec.rb
+++ b/spec/models/mac_authentication_bypass_spec.rb
@@ -11,16 +11,16 @@ describe MacAuthenticationBypass, type: :model do
   it { is_expected.to validate_uniqueness_of(:address).case_insensitive }
 
   it "validates the format of the MAC addresses" do
-    valid_mac_addresses = %i(
+    valid_mac_addresses = %i[
       aa-bb-cc-dd-ee-ff
       11-22-33-44-55-66
-    )
+    ]
 
-    invalid_mac_addresses = %i(
+    invalid_mac_addresses = %i[
       ab:cd:de:fg:hi:jk
       AA-BB-CC-DD-EE-FF
       AABBCCDDEEFF
-    )
+    ]
 
     valid_mac_addresses.each do |mac_address|
       result = build(:mac_authentication_bypass, address: mac_address)

--- a/spec/models/mac_authentication_bypass_spec.rb
+++ b/spec/models/mac_authentication_bypass_spec.rb
@@ -9,4 +9,27 @@ describe MacAuthenticationBypass, type: :model do
 
   it { is_expected.to validate_presence_of :address }
   it { is_expected.to validate_uniqueness_of(:address).case_insensitive }
+
+  it "validates the format of the MAC addresses" do
+    valid_mac_addresses = %i(
+      aa-bb-cc-dd-ee-ff
+      11-22-33-44-55-66
+    )
+
+    invalid_mac_addresses = %i(
+      ab:cd:de:fg:hi:jk
+      AA-BB-CC-DD-EE-FF
+      AABBCCDDEEFF
+    )
+
+    valid_mac_addresses.each do |mac_address|
+      result = build(:mac_authentication_bypass, address: mac_address)
+      expect(result).to be_valid
+    end
+
+    invalid_mac_addresses.each do |mac_address|
+      result = build(:mac_authentication_bypass, address: mac_address)
+      expect(result).to be_invalid
+    end
+  end
 end

--- a/spec/use_cases/generate_authorised_clients_spec.rb
+++ b/spec/use_cases/generate_authorised_clients_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+describe UseCases::GenerateAuthorisedClients do
+  subject(:result) do
+    described_class.new.call(mac_authentication_bypasses: mac_authentication_bypasses)
+  end
+
+  describe "#call" do
+    describe "When there are entries in the database" do
+      before do
+        create(:mac_authentication_bypass, address: "aa-11-22-33-44-55")
+        create(:mac_authentication_bypass, address: "ff-99-88-77-66-55")
+      end
+
+      let(:mac_authentication_bypasses) { MacAuthenticationBypass.all }
+
+      it 'generates a authorised_clients configuration file' do
+        expected_config = %(aa-11-22-33-44-55
+ff-99-88-77-66-55)
+
+        expect(result).to eq(expected_config)
+      end
+    end
+
+    describe "When there are no entries in the database" do
+      let(:mac_authentication_bypasses) { [] }
+
+      it "generates an empty authorised_clients configuration file" do
+        expect(result).to eq("")
+      end
+    end
+  end
+end

--- a/spec/use_cases/generate_authorised_clients_spec.rb
+++ b/spec/use_cases/generate_authorised_clients_spec.rb
@@ -14,7 +14,7 @@ describe UseCases::GenerateAuthorisedClients do
 
       let(:mac_authentication_bypasses) { MacAuthenticationBypass.all }
 
-      it 'generates a authorised_clients configuration file' do
+      it "generates a authorised_clients configuration file" do
         expected_config = %(aa-11-22-33-44-55
 ff-99-88-77-66-55)
 


### PR DESCRIPTION
Also validate the format fo MAC addresses being entered.
Ensure the input is correct at this stage and the format matches what
FreeRadius "rewrite_calling_station_id" function expects to match
against.
