### PR TITLE
Ensure the filename of the cert is unique

### DIFF
--- a/app/controllers/certificates_controller.rb
+++ b/app/controllers/certificates_controller.rb
@@ -88,7 +88,7 @@ private
     )
   end
 
-  def full_object_path(filename) 
+  def full_object_path(filename)
     (@certificate.category == "RADSEC" ? "radsec/" : "") + filename
   end
 end

--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -3,6 +3,7 @@ class Certificate < ApplicationRecord
   validates_presence_of :description
   validate :fields_from_certificate_file, on: :create
   validates_inclusion_of :category, in: %w[EAP RADSEC]
+  validates_uniqueness_of :filename
 
 private
 

--- a/db/migrate/20210721113743_change_filename_column_to_unique_in_certificates.rb
+++ b/db/migrate/20210721113743_change_filename_column_to_unique_in_certificates.rb
@@ -1,0 +1,5 @@
+class ChangeFilenameColumnToUniqueInCertificates < ActiveRecord::Migration[6.1]
+  def change
+    change_column :certificates, :filename, :text, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_20_131344) do
+ActiveRecord::Schema.define(version: 2021_07_21_113743) do
 
   create_table "audits", charset: "utf8", force: :cascade do |t|
     t.integer "auditable_id"

--- a/spec/models/certificate_spec.rb
+++ b/spec/models/certificate_spec.rb
@@ -12,7 +12,6 @@ describe Certificate, type: :model do
   it { is_expected.to validate_uniqueness_of(:name).case_insensitive }
   it { is_expected.to validate_uniqueness_of(:filename).case_insensitive }
 
-
   it "raises an error when fields from certificate file are missing" do
     missing_field = [{ expiry_date: Date.today }, { subject: "may not exist" }].sample
     params = { name: "My new certificate", description: "bar" }.merge(missing_field)

--- a/spec/models/certificate_spec.rb
+++ b/spec/models/certificate_spec.rb
@@ -10,6 +10,8 @@ describe Certificate, type: :model do
   it { is_expected.to validate_presence_of :name }
   it { is_expected.to validate_presence_of :description }
   it { is_expected.to validate_uniqueness_of(:name).case_insensitive }
+  it { is_expected.to validate_uniqueness_of(:filename).case_insensitive }
+
 
   it "raises an error when fields from certificate file are missing" do
     missing_field = [{ expiry_date: Date.today }, { subject: "may not exist" }].sample


### PR DESCRIPTION
This stops overwriting of certs on the S3 bucket
And accidentally deleting the wrong cert.