### PR TITLE
Generate authorised clients configuration file

### DIFF
--- a/app/lib/use_cases/generate_authorised_clients.rb
+++ b/app/lib/use_cases/generate_authorised_clients.rb
@@ -1,10 +1,10 @@
 class UseCases::GenerateAuthorisedClients
   def call(clients:)
     output = clients.map do |client|
-      if IPAddress.valid_ipv6_subnet? client.ip_range
-        "client #{client.tag.sub(" ", "_").downcase} {\n\tipv6addr = #{client.ip_range}\n\tsecret = #{client.shared_secret}\n}"
-      else
+      if IPAddress.valid_ipv4_subnet?(client.ip_range)
         "client #{client.tag.sub(" ", "_").downcase} {\n\tipv4addr = #{client.ip_range}\n\tsecret = #{client.shared_secret}\n}"
+      else
+        "client #{client.tag.sub(" ", "_").downcase} {\n\tipv6addr = #{client.ip_range}\n\tsecret = #{client.shared_secret}\n}"
       end
     end
 

--- a/app/lib/use_cases/generate_authorised_clients.rb
+++ b/app/lib/use_cases/generate_authorised_clients.rb
@@ -1,9 +1,9 @@
 class UseCases::GenerateAuthorisedClients
   def call(clients:)
-    result = ""
-    clients.map do |client|
-      result += "\nclient #{client.tag} {\nipv4addr = #{client.ip_range}\nsecret = #{client.shared_secret}\n}"
+    output = clients.map do |client|
+      "client #{client.tag.sub(" ", "_").downcase} {\n\tipv4addr = #{client.ip_range}\n\tsecret = #{client.shared_secret}\n}"
     end
-    result += "\n"
+
+    output.join("\n\n")
   end
 end

--- a/app/lib/use_cases/generate_authorised_clients.rb
+++ b/app/lib/use_cases/generate_authorised_clients.rb
@@ -1,7 +1,11 @@
 class UseCases::GenerateAuthorisedClients
   def call(clients:)
     output = clients.map do |client|
-      "client #{client.tag.sub(" ", "_").downcase} {\n\tipv4addr = #{client.ip_range}\n\tsecret = #{client.shared_secret}\n}"
+      if IPAddress.valid_ipv6_subnet? client.ip_range
+        "client #{client.tag.sub(" ", "_").downcase} {\n\tipv6addr = #{client.ip_range}\n\tsecret = #{client.shared_secret}\n}"
+      else
+        "client #{client.tag.sub(" ", "_").downcase} {\n\tipv4addr = #{client.ip_range}\n\tsecret = #{client.shared_secret}\n}"
+      end
     end
 
     output.join("\n\n")

--- a/app/lib/use_cases/generate_authorised_clients.rb
+++ b/app/lib/use_cases/generate_authorised_clients.rb
@@ -2,9 +2,9 @@ class UseCases::GenerateAuthorisedClients
   def call(clients:)
     output = clients.map do |client|
       if IPAddress.valid_ipv4_subnet?(client.ip_range)
-        "client #{client.tag.sub(" ", "_").downcase} {\n\tipv4addr = #{client.ip_range}\n\tsecret = #{client.shared_secret}\n}"
+        "client #{client.ip_range} {\n\tipv4addr = #{client.ip_range}\n\tsecret = #{client.shared_secret}\n\tshortname = #{client.tag}\n}"
       else
-        "client #{client.tag.sub(" ", "_").downcase} {\n\tipv6addr = #{client.ip_range}\n\tsecret = #{client.shared_secret}\n}"
+        "client #{client.ip_range} {\n\tipv6addr = #{client.ip_range}\n\tsecret = #{client.shared_secret}\n\tshortname = #{client.tag}\n}"
       end
     end
 

--- a/app/lib/use_cases/generate_authorised_clients.rb
+++ b/app/lib/use_cases/generate_authorised_clients.rb
@@ -1,0 +1,9 @@
+class UseCases::GenerateAuthorisedClients
+  def call(clients:)
+    result = ""
+    clients.map do |client|
+      result += "\nclient #{client.tag} {\nipv4addr = #{client.ip_range}\nsecret = #{client.shared_secret}\n}"
+    end
+    result += "\n"
+  end
+end

--- a/app/lib/use_cases/generate_authorised_clients.rb
+++ b/app/lib/use_cases/generate_authorised_clients.rb
@@ -1,13 +1,19 @@
 class UseCases::GenerateAuthorisedClients
   def call(clients:)
     output = clients.map do |client|
-      if IPAddress.valid_ipv4_subnet?(client.ip_range)
-        "client #{client.ip_range} {\n\tipv4addr = #{client.ip_range}\n\tsecret = #{client.shared_secret}\n\tshortname = #{client.tag}\n}"
-      else
-        "client #{client.ip_range} {\n\tipv6addr = #{client.ip_range}\n\tsecret = #{client.shared_secret}\n\tshortname = #{client.tag}\n}"
-      end
+      client_definition(client)
     end
 
     output.join("\n\n")
+  end
+
+private
+
+  def client_definition(client)
+    "client #{client.ip_range} {\n\t#{ip_version(client.ip_range)} = #{client.ip_range}\n\tsecret = #{client.shared_secret}\n\tshortname = #{client.tag}\n}"
+  end
+
+  def ip_version(ip_range)
+    IPAddress.valid_ipv4_subnet?(ip_range) ? "ipv4addr" : "ipv6addr"
   end
 end

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -9,7 +9,7 @@ private
   def validate_ip
     return if ip_range.blank?
 
-    errors.add(:ip_range, "is invalid") unless IPAddress.valid?(ip_range)
+    errors.add(:ip_range, "is invalid") unless IPAddress.valid_ipv4_subnet?(ip_range) || IPAddress.valid_ipv6_subnet?(ip_range)
   end
 
   audited

--- a/spec/acceptance/clients/create_clients_spec.rb
+++ b/spec/acceptance/clients/create_clients_spec.rb
@@ -18,7 +18,7 @@ describe "create clients", type: :feature do
 
         expect(page.current_path).to eq(new_site_client_path(site_id: site))
 
-        fill_in "IP / Subnet CIDR", with: "123.123.123.123"
+        fill_in "IP / Subnet CIDR", with: "123.123.123.123/32"
         fill_in "Tag", with: "Some client"
 
         click_on "Create"

--- a/spec/factories/client.rb
+++ b/spec/factories/client.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     site
 
     sequence(:tag) { |n| "Client #{n}" }
-    sequence(:shared_secret) { |n| "Shared secret #{n}" }
+    sequence(:shared_secret) { |n| "shared-secret-#{n}" }
     sequence(:ip_range) { |n| "127.0.0.#{n}" }
   end
 end

--- a/spec/factories/client.rb
+++ b/spec/factories/client.rb
@@ -4,6 +4,6 @@ FactoryBot.define do
 
     sequence(:tag) { |n| "Client #{n}" }
     sequence(:shared_secret) { |n| "shared-secret-#{n}" }
-    sequence(:ip_range) { |n| "127.0.0.#{n}" }
+    sequence(:ip_range) { |n| "127.0.0.#{n}/32" }
   end
 end

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -16,6 +16,7 @@ describe Client, type: :model do
     valid_ip_addresses = %i[
       10.0.0.1/32
       10.0.0.2/24
+      2001:0db8:85a3:0000:0000:8a2e:0370:7334/32
     ]
 
     invalid_ip_addresses = %i[

--- a/spec/use_cases/generate_authorised_clients_spec.rb
+++ b/spec/use_cases/generate_authorised_clients_spec.rb
@@ -12,7 +12,7 @@ describe UseCases::GenerateAuthorisedClients do
 			let!(:second_ipv4_client) { create(:client, ip_range: "123.123.0.2/32") }
 			let(:clients) { Client.all }
 
-        it "generates a authorised_clients configuration file" do
+        it "generates an authorised clients configuration file" do
           expected_config = "client #{first_ipv4_client.tag.sub(" ", "_").downcase} {
 \tipv4addr = 123.123.0.1/24
 \tsecret = #{first_ipv4_client.shared_secret}
@@ -32,7 +32,7 @@ client #{second_ipv4_client.tag.sub(" ", "_").downcase} {
 			  let!(:second_ipv6_client) { create(:client, ip_range: "2002::1/128") }
   			let(:clients) { Client.all }
 
-        it "generates a authorised_clients configuration file" do
+        it "generates an authorised clients configuration file" do
           expected_config = "client #{first_ipv6_client.tag.sub(" ", "_").downcase} {
 \tipv6addr = 2001:0db8:85a3:0000:0000:8a2e:0370:7334/32
 \tsecret = #{first_ipv6_client.shared_secret}
@@ -51,7 +51,7 @@ client #{second_ipv6_client.tag.sub(" ", "_").downcase} {
 		describe "when there are no entries in the database" do
 		  let(:clients) { [] }
 
-		  it "generates an empty authorised_clients configuration file" do
+		  it "generates an empty authorised clients configuration file" do
 		    expect(result).to eq("")
 		  end
 		end

--- a/spec/use_cases/generate_authorised_clients_spec.rb
+++ b/spec/use_cases/generate_authorised_clients_spec.rb
@@ -1,26 +1,28 @@
 require "rails_helper"
 
 describe UseCases::GenerateAuthorisedClients do
-	subject(:result) do
-		described_class.new.call(clients: clients)
-	end
+  subject(:result) do
+    described_class.new.call(clients: clients)
+  end
 
-	describe "#call" do
-		describe "when there are entries in the database" do
+  describe "#call" do
+    describe "when there are entries in the database" do
       context "and the IP ranges are IPv4" do
-			let!(:first_ipv4_client) { create(:client, ip_range: "123.123.0.1/24") }
-			let!(:second_ipv4_client) { create(:client, ip_range: "123.123.0.2/32") }
-			let(:clients) { Client.all }
+        let!(:first_ipv4_client) { create(:client, ip_range: "123.123.0.1/24") }
+        let!(:second_ipv4_client) { create(:client, ip_range: "123.123.0.2/32") }
+        let(:clients) { Client.all }
 
         it "generates an authorised clients configuration file" do
-          expected_config = "client #{first_ipv4_client.tag.sub(" ", "_").downcase} {
-\tipv4addr = 123.123.0.1/24
+          expected_config = "client #{first_ipv4_client.ip_range} {
+\tipv4addr = #{first_ipv4_client.ip_range}
 \tsecret = #{first_ipv4_client.shared_secret}
+\tshortname = #{first_ipv4_client.tag}
 }
 
-client #{second_ipv4_client.tag.sub(" ", "_").downcase} {
+client #{second_ipv4_client.ip_range} {
 \tipv4addr = 123.123.0.2/32
 \tsecret = #{second_ipv4_client.shared_secret}
+\tshortname = #{second_ipv4_client.tag}
 }"
 
           expect(result).to eq(expected_config)
@@ -28,32 +30,34 @@ client #{second_ipv4_client.tag.sub(" ", "_").downcase} {
       end
 
       context "and the IP ranges are IPv6" do
-			  let!(:first_ipv6_client) { create(:client, ip_range: "2001:0db8:85a3:0000:0000:8a2e:0370:7334/32") }
-			  let!(:second_ipv6_client) { create(:client, ip_range: "2002::1/128") }
-  			let(:clients) { Client.all }
+        let!(:first_ipv6_client) { create(:client, ip_range: "2001:0db8:85a3:0000:0000:8a2e:0370:7334/32") }
+        let!(:second_ipv6_client) { create(:client, ip_range: "2002::1/128") }
+        let(:clients) { Client.all }
 
         it "generates an authorised clients configuration file" do
-          expected_config = "client #{first_ipv6_client.tag.sub(" ", "_").downcase} {
-\tipv6addr = 2001:0db8:85a3:0000:0000:8a2e:0370:7334/32
+          expected_config = "client #{first_ipv6_client.ip_range} {
+\tipv6addr = #{first_ipv6_client.ip_range}
 \tsecret = #{first_ipv6_client.shared_secret}
+\tshortname = #{first_ipv6_client.tag}
 }
 
-client #{second_ipv6_client.tag.sub(" ", "_").downcase} {
-\tipv6addr = 2002::1/128
+client #{second_ipv6_client.ip_range} {
+\tipv6addr = #{second_ipv6_client.ip_range}
 \tsecret = #{second_ipv6_client.shared_secret}
+\tshortname = #{second_ipv6_client.tag}
 }"
 
           expect(result).to eq(expected_config)
         end
       end
-		end
+    end
 
-		describe "when there are no entries in the database" do
-		  let(:clients) { [] }
+    describe "when there are no entries in the database" do
+      let(:clients) { [] }
 
-		  it "generates an empty authorised clients configuration file" do
-		    expect(result).to eq("")
-		  end
-		end
-	end
+      it "generates an empty authorised clients configuration file" do
+        expect(result).to eq("")
+      end
+    end
+  end
 end

--- a/spec/use_cases/generate_authorised_clients_spec.rb
+++ b/spec/use_cases/generate_authorised_clients_spec.rb
@@ -6,19 +6,19 @@ describe UseCases::GenerateAuthorisedClients do
 	end
 
 	describe "#call" do
-		describe "When there are entries in the database" do
-			let(:first_client) { create(:client, ip_range: "123.123.0.1") }
-			let(:second_client) { create(:client, ip_range: "123.123.0.2") }
+		describe "when there are entries in the database" do
+			let(:first_client) { create(:client, ip_range: "123.123.0.1/24") }
+			let(:second_client) { create(:client, ip_range: "123.123.0.2/32") }
 			let(:clients) { Client.all }
 
 			it "generates a authorised_clients configuration file" do
 				expected_config = "client #{first_client.tag.sub(" ", "_").downcase} {
-\tipv4addr = 123.123.0.1
+\tipv4addr = 123.123.0.1/24
 \tsecret = #{first_client.shared_secret}
 }
 
 client #{second_client.tag.sub(" ", "_").downcase} {
-\tipv4addr = 123.123.0.2
+\tipv4addr = 123.123.0.2/32
 \tsecret = #{second_client.shared_secret}
 }"
 
@@ -26,7 +26,7 @@ client #{second_client.tag.sub(" ", "_").downcase} {
 			end
 		end
 
-		describe "When there are no entries in the database" do
+		describe "when there are no entries in the database" do
 		  let(:clients) { [] }
 
 		  it "generates an empty authorised_clients configuration file" do

--- a/spec/use_cases/generate_authorised_clients_spec.rb
+++ b/spec/use_cases/generate_authorised_clients_spec.rb
@@ -7,23 +7,45 @@ describe UseCases::GenerateAuthorisedClients do
 
 	describe "#call" do
 		describe "when there are entries in the database" do
-			let(:first_client) { create(:client, ip_range: "123.123.0.1/24") }
-			let(:second_client) { create(:client, ip_range: "123.123.0.2/32") }
+      context "and the IP ranges are IPv4" do
+			let(:first_ipv4_client) { create(:client, ip_range: "123.123.0.1/24") }
+			let(:second_ipv4_client) { create(:client, ip_range: "123.123.0.2/32") }
 			let(:clients) { Client.all }
 
-			it "generates a authorised_clients configuration file" do
-				expected_config = "client #{first_client.tag.sub(" ", "_").downcase} {
+        it "generates a authorised_clients configuration file" do
+          expected_config = "client #{first_ipv4_client.tag.sub(" ", "_").downcase} {
 \tipv4addr = 123.123.0.1/24
-\tsecret = #{first_client.shared_secret}
+\tsecret = #{first_ipv4_client.shared_secret}
 }
 
-client #{second_client.tag.sub(" ", "_").downcase} {
+client #{second_ipv4_client.tag.sub(" ", "_").downcase} {
 \tipv4addr = 123.123.0.2/32
-\tsecret = #{second_client.shared_secret}
+\tsecret = #{second_ipv4_client.shared_secret}
 }"
 
-				expect(result).to include(expected_config)
-			end
+          expect(result).to include(expected_config)
+        end
+      end
+
+      context "and the IP ranges are IPv6" do
+			  let(:first_ipv6_client) { create(:client, ip_range: "2001:0db8:85a3:0000:0000:8a2e:0370:7334/32") }
+			  let(:second_ipv6_client) { create(:client, ip_range: "2002::1/128") }
+  			let(:clients) { Client.all }
+
+        it "generates a authorised_clients configuration file" do
+          expected_config = "client #{first_ipv6_client.tag.sub(" ", "_").downcase} {
+\tipv6addr = 2001:0db8:85a3:0000:0000:8a2e:0370:7334/32
+\tsecret = #{first_ipv6_client.shared_secret}
+}
+
+client #{second_ipv6_client.tag.sub(" ", "_").downcase} {
+\tipv6addr = 2002::1/128
+\tsecret = #{second_ipv6_client.shared_secret}
+}"
+
+          expect(result).to include(expected_config)
+        end
+      end
 		end
 
 		describe "when there are no entries in the database" do

--- a/spec/use_cases/generate_authorised_clients_spec.rb
+++ b/spec/use_cases/generate_authorised_clients_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+describe UseCases::GenerateAuthorisedClients do
+  subject(:result) do
+    described_class.new.call(clients: clients)
+  end
+
+  describe "#call" do
+    describe "When there are entries in the database" do
+      let(:first_client) { create(:client, ip_range: "123.123.0.1") }
+      let(:second_client) { create(:client, ip_range: "123.123.0.2") }
+      let(:clients) { Client.all }
+
+      it "generates a authorised_clients configuration file" do
+        expected_config = """
+client #{first_client.tag} {
+ipv4addr = 123.123.0.1
+secret = #{first_client.shared_secret}
+}
+client #{second_client.tag} {
+ipv4addr = 123.123.0.2
+secret = #{second_client.shared_secret}
+}
+"""
+
+        expect(result).to include(expected_config)
+      end
+    end
+
+    # describe "When there are no entries in the database" do
+    #   let(:mac_authentication_bypasses) { [] }
+
+    #   it "generates an empty authorised_clients configuration file" do
+    #     expect(result).to eq("")
+    #   end
+    # end
+  end
+end

--- a/spec/use_cases/generate_authorised_clients_spec.rb
+++ b/spec/use_cases/generate_authorised_clients_spec.rb
@@ -8,8 +8,8 @@ describe UseCases::GenerateAuthorisedClients do
 	describe "#call" do
 		describe "when there are entries in the database" do
       context "and the IP ranges are IPv4" do
-			let(:first_ipv4_client) { create(:client, ip_range: "123.123.0.1/24") }
-			let(:second_ipv4_client) { create(:client, ip_range: "123.123.0.2/32") }
+			let!(:first_ipv4_client) { create(:client, ip_range: "123.123.0.1/24") }
+			let!(:second_ipv4_client) { create(:client, ip_range: "123.123.0.2/32") }
 			let(:clients) { Client.all }
 
         it "generates a authorised_clients configuration file" do
@@ -23,13 +23,13 @@ client #{second_ipv4_client.tag.sub(" ", "_").downcase} {
 \tsecret = #{second_ipv4_client.shared_secret}
 }"
 
-          expect(result).to include(expected_config)
+          expect(result).to eq(expected_config)
         end
       end
 
       context "and the IP ranges are IPv6" do
-			  let(:first_ipv6_client) { create(:client, ip_range: "2001:0db8:85a3:0000:0000:8a2e:0370:7334/32") }
-			  let(:second_ipv6_client) { create(:client, ip_range: "2002::1/128") }
+			  let!(:first_ipv6_client) { create(:client, ip_range: "2001:0db8:85a3:0000:0000:8a2e:0370:7334/32") }
+			  let!(:second_ipv6_client) { create(:client, ip_range: "2002::1/128") }
   			let(:clients) { Client.all }
 
         it "generates a authorised_clients configuration file" do
@@ -43,7 +43,7 @@ client #{second_ipv6_client.tag.sub(" ", "_").downcase} {
 \tsecret = #{second_ipv6_client.shared_secret}
 }"
 
-          expect(result).to include(expected_config)
+          expect(result).to eq(expected_config)
         end
       end
 		end

--- a/spec/use_cases/generate_authorised_clients_spec.rb
+++ b/spec/use_cases/generate_authorised_clients_spec.rb
@@ -1,38 +1,37 @@
 require "rails_helper"
 
 describe UseCases::GenerateAuthorisedClients do
-  subject(:result) do
-    described_class.new.call(clients: clients)
-  end
+	subject(:result) do
+		described_class.new.call(clients: clients)
+	end
 
-  describe "#call" do
-    describe "When there are entries in the database" do
-      let(:first_client) { create(:client, ip_range: "123.123.0.1") }
-      let(:second_client) { create(:client, ip_range: "123.123.0.2") }
-      let(:clients) { Client.all }
+	describe "#call" do
+		describe "When there are entries in the database" do
+			let(:first_client) { create(:client, ip_range: "123.123.0.1") }
+			let(:second_client) { create(:client, ip_range: "123.123.0.2") }
+			let(:clients) { Client.all }
 
-      it "generates a authorised_clients configuration file" do
-        expected_config = """
-client #{first_client.tag} {
-ipv4addr = 123.123.0.1
-secret = #{first_client.shared_secret}
+			it "generates a authorised_clients configuration file" do
+				expected_config = "client #{first_client.tag.sub(" ", "_").downcase} {
+\tipv4addr = 123.123.0.1
+\tsecret = #{first_client.shared_secret}
 }
-client #{second_client.tag} {
-ipv4addr = 123.123.0.2
-secret = #{second_client.shared_secret}
-}
-"""
 
-        expect(result).to include(expected_config)
-      end
-    end
+client #{second_client.tag.sub(" ", "_").downcase} {
+\tipv4addr = 123.123.0.2
+\tsecret = #{second_client.shared_secret}
+}"
 
-    # describe "When there are no entries in the database" do
-    #   let(:mac_authentication_bypasses) { [] }
+				expect(result).to include(expected_config)
+			end
+		end
 
-    #   it "generates an empty authorised_clients configuration file" do
-    #     expect(result).to eq("")
-    #   end
-    # end
-  end
+		describe "When there are no entries in the database" do
+		  let(:clients) { [] }
+
+		  it "generates an empty authorised_clients configuration file" do
+		    expect(result).to eq("")
+		  end
+		end
+	end
 end


### PR DESCRIPTION
## Context

- allow the generation of client configuration file for authorised clients
- the IP range / CIDR subnet is the client function name
- the tag is the short name for the client
- there is distinction between IPv4 and IPv6 addresses, so the correct config. is generated
- client model is updated to validate IPv4 and IPv6 subnet

Note: for a single IP address, we have decided to use /32 in the case for an IPv4 address, and /128 in the case for an IPv6 address. This may impact the user interface where we input the IP range when creating a client.
