### PR TITLE
Publish authorised clients file into s3 bucket

### DIFF
--- a/app/controllers/clients_controller.rb
+++ b/app/controllers/clients_controller.rb
@@ -45,6 +45,7 @@ class ClientsController < ApplicationController
     authorize! :destroy, @client
     if confirmed?
       if @client.destroy
+        publish_authorised_clients
         redirect_to site_path(@site), notice: "Successfully deleted client. "
       else
         redirect_to site_path(@site), error: "Failed to delete the client. "

--- a/spec/acceptance/clients/create_clients_spec.rb
+++ b/spec/acceptance/clients/create_clients_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 describe "create clients", type: :feature do
   context "when the user is an editor" do
     let(:editor) { create(:user, :editor) }
-    let!(:publish_to_s3) { instance_double(UseCases::PublishToS3) }
-    let!(:s3_gateway) { double(Gateways::S3) }
+    let(:publish_to_s3) { instance_double(UseCases::PublishToS3) }
+    let(:s3_gateway) { double(Gateways::S3) }
 
     before do
       login_as editor
@@ -35,12 +35,12 @@ describe "create clients", type: :feature do
 
         click_on "Create"
 
-        expected_config = "client 123.123.123.123/32 {
+        expected_config_file = "client 123.123.123.123/32 {
 \tipv4addr = 123.123.123.123/32
 \tsecret = #{Client.first.shared_secret}
 \tshortname = Some client
 }"
-        expect(publish_to_s3).to have_received(:call).with(expected_config)
+        expect(publish_to_s3).to have_received(:call).with(expected_config_file)
         expect(page).to have_content("Successfully created client.")
         expect(page.current_path).to eq(site_path(id: site.id))
         expect_audit_log_entry_for(editor.email, "create", "Client")

--- a/spec/acceptance/clients/update_clients_spec.rb
+++ b/spec/acceptance/clients/update_clients_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 describe "update clients", type: :feature do
   let(:site) { create(:site) }
   let(:client) { create(:client, site: site) }
-  let!(:publish_to_s3) { instance_double(UseCases::PublishToS3) }
-  let!(:s3_gateway) { double(Gateways::S3) }
+  let(:publish_to_s3) { instance_double(UseCases::PublishToS3) }
+  let(:s3_gateway) { double(Gateways::S3) }
 
   context "when the user is unauthenticated" do
     it "does not allow updating clients" do
@@ -61,12 +61,12 @@ describe "update clients", type: :feature do
 
       click_on "Update"
 
-      expected_config = "client 132.111.132.111/32 {
+      expected_config_file = "client 132.111.132.111/32 {
 \tipv4addr = 132.111.132.111/32
 \tsecret = #{Client.first.shared_secret}
 \tshortname = Updated client
 }"
-      expect(publish_to_s3).to have_received(:call).with(expected_config)
+      expect(publish_to_s3).to have_received(:call).with(expected_config_file)
 
       expect(current_path).to eq("/sites/#{site.id}")
 


### PR DESCRIPTION
## What:
- Initialise an s3 gateway with the correct configuration
- Call the `GenerateAuthorisedClients` use-case
- And publish the file into s3 when:
  - An authorised client is created
  - An authorised client is updated
  - An authorised client is deleted

## Why:
So the latest config is available when the RADIUS server is redeployed