### PR TITLE
Disable fallback checkbox when editing a policy

### DIFF
--- a/app/controllers/rules_controller.rb
+++ b/app/controllers/rules_controller.rb
@@ -1,5 +1,6 @@
 class RulesController < ApplicationController
   before_action :set_policy, only: %i[new create destroy edit update]
+  before_action :redirect_to_policies_path
 
   def new
     @rule = Rule.new
@@ -61,5 +62,9 @@ private
 
   def rule_params
     params.require(:rule).permit(:request_attribute, :value, :operator)
+  end
+
+  def redirect_to_policies_path
+    redirect_to policies_path if @policy.fallback?
   end
 end

--- a/app/views/policies/_form.html.erb
+++ b/app/views/policies/_form.html.erb
@@ -12,7 +12,7 @@
   <div class="govuk-form-group">
     <div class="govuk-checkboxes" data-module="govuk-checkboxes">
       <div class="govuk-checkboxes__item">
-        <%= f.check_box :fallback, class: "govuk-checkboxes__input" %>
+        <%= f.check_box :fallback, disabled: !f.object.new_record?, class: "govuk-checkboxes__input" %>
         <%= f.label :fallback, class: "govuk-label govuk-checkboxes__label" %>
       </div>
     </div>

--- a/spec/acceptance/policy/rules/create_rules_spec.rb
+++ b/spec/acceptance/policy/rules/create_rules_spec.rb
@@ -41,10 +41,14 @@ describe "create rules", type: :feature do
     context "when there is an existing fallback policy" do
       let!(:policy) { create(:policy, fallback: true) }
 
-      it "does not create a new rule" do
+      it "does not allow creating rules" do
         visit "/policies/#{policy.id}"
 
         expect(page).to_not have_content "Add rule"
+
+        visit "/policies/#{policy.id}/rules/new"
+
+        expect(page.current_path).to eq(policies_path)
       end
     end
   end

--- a/spec/acceptance/policy/update_policies_spec.rb
+++ b/spec/acceptance/policy/update_policies_spec.rb
@@ -42,6 +42,8 @@ describe "update policies", type: :feature do
 
       expect(page).to have_field("Name", with: policy.name)
 
+      expect(page).to have_field("policy_fallback", type: "checkbox", disabled: true)
+
       fill_in "Name", with: "My London Policy"
 
       click_on "Update"


### PR DESCRIPTION
- Prevent adding rules to fallback policies
- Disable fallback checkbox on policy edit/update 