### PR TITLE
Attach policies to sites

### DIFF
--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -1,5 +1,5 @@
 class SitesController < ApplicationController
-  before_action :set_site, only: %i[show edit update destroy policies]
+  before_action :set_site, only: %i[show edit update destroy policies attach_policies]
 
   def index
     @sites = Site.all
@@ -59,9 +59,15 @@ class SitesController < ApplicationController
   end
 
   def attach_policies
-    # todo:
-    # attach the policies to the site
-    # redirect to the site path
+    @site.policies = add_policies_to_site
+
+    puts "something here"
+
+    if @site.save
+      redirect_to site_path(@site), notice: "Successfully attached policies to the site. "
+    else
+      render :policies
+    end
   end
 
 private
@@ -76,5 +82,14 @@ private
 
   def set_site
     @site = Site.find(site_id)
+  end
+
+  def add_policies_to_site
+    Policy.all.map { |policy|
+      policy_id = params["policy_#{policy.id}"]
+      unless policy_id.nil?
+        Policy.find(policy_id.to_i)
+      end
+    }.compact!
   end
 end

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -59,6 +59,8 @@ class SitesController < ApplicationController
   end
 
   def attach_policies
+    authorize! :attach_policies, @site
+
     @site.policies
 
     if policies_params.any?
@@ -67,7 +69,9 @@ class SitesController < ApplicationController
       policies_params.each do |id|
         @site.policies << Policy.find(id)
       end
+    end
 
+    if @site.save
       redirect_to site_path(@site), notice: "Successfully attached policies to the site. "
     else
       render :policies

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -61,14 +61,16 @@ class SitesController < ApplicationController
   def attach_policies
     authorize! :attach_policies, @site
 
-    @site.policies
+puts policies_params
 
     if policies_params.any?
-
       @site.policies.clear
+
       policies_params.each do |id|
         @site.policies << Policy.find(id)
       end
+    else
+      @site.policies.clear
     end
 
     if @site.save

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -59,11 +59,15 @@ class SitesController < ApplicationController
   end
 
   def attach_policies
-    @site.policies = add_policies_to_site
+    @site.policies
 
-    puts "something here"
+    if policies_params.any?
 
-    if @site.save
+      @site.policies.clear
+      policies_params.each do |id|
+        @site.policies << Policy.find(id)
+      end
+
       redirect_to site_path(@site), notice: "Successfully attached policies to the site. "
     else
       render :policies
@@ -84,12 +88,7 @@ private
     @site = Site.find(site_id)
   end
 
-  def add_policies_to_site
-    Policy.all.map { |policy|
-      policy_id = params["policy_#{policy.id}"]
-      unless policy_id.nil?
-        Policy.find(policy_id.to_i)
-      end
-    }.compact!
+  def policies_params
+    params.require(:policy_ids).reject(&:empty?)
   end
 end

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -61,17 +61,16 @@ class SitesController < ApplicationController
   def attach_policies
     authorize! :attach_policies, @site
 
-puts policies_params
+    policies = []
 
     if policies_params.any?
-      @site.policies.clear
 
       policies_params.each do |id|
-        @site.policies << Policy.find(id)
+        policies << Policy.find(id)
       end
-    else
-      @site.policies.clear
     end
+
+    @site.assign_attributes(policies: policies)
 
     if @site.save
       redirect_to site_path(@site), notice: "Successfully attached policies to the site. "

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -1,5 +1,5 @@
 class SitesController < ApplicationController
-  before_action :set_site, only: %i[show edit update destroy]
+  before_action :set_site, only: %i[show edit update destroy policies]
 
   def index
     @sites = Site.all
@@ -52,6 +52,16 @@ class SitesController < ApplicationController
     else
       render "sites/destroy"
     end
+  end
+
+  def policies
+    @policies = Policy.all
+  end
+
+  def attach_policies
+    # todo:
+    # attach the policies to the site
+    # redirect to the site path
   end
 
 private

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -73,7 +73,7 @@ class SitesController < ApplicationController
     @site.assign_attributes(policies: policies)
 
     if @site.save
-      redirect_to site_path(@site), notice: "Successfully attached policies to the site. "
+      redirect_to site_path(@site), notice: "Successfully updated site policies."
     else
       render :policies
     end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -2,7 +2,7 @@ class Site < ApplicationRecord
   validates :name, presence: true, uniqueness: { case_sensitive: false }
 
   has_many :clients, dependent: :destroy
-  has_and_belongs_to_many :policies
+  has_and_belongs_to_many :policies, -> { distinct }
 
   audited
 end

--- a/app/views/policies/_form.html.erb
+++ b/app/views/policies/_form.html.erb
@@ -27,7 +27,6 @@
   class: "govuk-button govuk-button--secondary",
   data: {
     module: "govuk-button"
-  }
-%>
+  } %>
 
 <% end %>

--- a/app/views/sites/policies.html.erb
+++ b/app/views/sites/policies.html.erb
@@ -10,7 +10,7 @@
 
       <% @policies.each do |policy| %>
         <div class="govuk-checkboxes__item">
-          <%= f.check_box policy.name, class: "govuk-checkboxes__input" %>
+          <%= f.check_box "policy_#{policy.id}", { class: "govuk-checkboxes__input" }, policy.id, nil %>
           <%= f.label policy.name, class: "govuk-label govuk-checkboxes__label" %>
         </div>
       <% end %>

--- a/app/views/sites/policies.html.erb
+++ b/app/views/sites/policies.html.erb
@@ -7,13 +7,12 @@
         Select all policies to attach to this site.
       </div>
       <div class="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
-
-      <% @policies.each do |policy| %>
-        <div class="govuk-checkboxes__item">
-          <%= f.check_box "policy_#{policy.id}", { class: "govuk-checkboxes__input" }, policy.id, nil %>
-          <%= f.label policy.name, class: "govuk-label govuk-checkboxes__label" %>
-        </div>
-      <% end %>
+        <%= f.collection_check_boxes :policy_ids, Policy.all, :id, :name do |b| %>
+          <div class="govuk-checkboxes__item">
+            <%= b.check_box class: "govuk-checkboxes__input" %>
+            <%= b.label class: "govuk-label govuk-checkboxes__label" %>
+          </div>
+        <% end %>
       </div>
     </fieldset>
   </div>

--- a/app/views/sites/policies.html.erb
+++ b/app/views/sites/policies.html.erb
@@ -7,9 +7,11 @@
         Select all policies to attach to this site.
       </div>
       <div class="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
+        <% site_policies_ids = @site.policies.map { |policy| policy.id } %>
+
         <%= f.collection_check_boxes :policy_ids, Policy.all, :id, :name do |b| %>
           <div class="govuk-checkboxes__item">
-            <%= b.check_box class: "govuk-checkboxes__input" %>
+            <%= b.check_box class: "govuk-checkboxes__input", checked: site_policies_ids.include?(b.object.id) %>
             <%= b.label class: "govuk-label govuk-checkboxes__label" %>
           </div>
         <% end %>

--- a/app/views/sites/policies.html.erb
+++ b/app/views/sites/policies.html.erb
@@ -1,6 +1,6 @@
 <h2 class="govuk-heading-l"><%= @site.name %></h2>
 
-<%= form_with do |f| %>
+<%= form_with local: true do |f| %>
   <div class="govuk-form-group">
     <fieldset class="govuk-fieldset" aria-describedby="contact-hint">
       <div id="contact-hint" class="govuk-hint">

--- a/app/views/sites/policies.html.erb
+++ b/app/views/sites/policies.html.erb
@@ -19,7 +19,7 @@
     </fieldset>
   </div>
 
-  <%= f.submit "Attach", {
+  <%= f.submit "Update", {
     class: "govuk-button",
     "data-module" => "govuk-button"
   } %>

--- a/app/views/sites/policies.html.erb
+++ b/app/views/sites/policies.html.erb
@@ -1,0 +1,32 @@
+<h2 class="govuk-heading-l"><%= @site.name %></h2>
+
+<%= form_with do |f| %>
+  <div class="govuk-form-group">
+    <fieldset class="govuk-fieldset" aria-describedby="contact-hint">
+      <div id="contact-hint" class="govuk-hint">
+        Select all policies to attach to this site.
+      </div>
+      <div class="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
+
+      <% @policies.each do |policy| %>
+        <div class="govuk-checkboxes__item">
+          <%= f.check_box policy.name, class: "govuk-checkboxes__input" %>
+          <%= f.label policy.name, class: "govuk-label govuk-checkboxes__label" %>
+        </div>
+      <% end %>
+      </div>
+    </fieldset>
+  </div>
+
+  <%= f.submit "Attach", {
+    class: "govuk-button",
+    "data-module" => "govuk-button"
+  } %>
+
+  <%= link_to "Cancel", @site,
+  class: "govuk-button govuk-button--secondary",
+  data: {
+    module: "govuk-button"
+  } %>
+
+<% end %>

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -20,6 +20,19 @@
   <%= link_to "Add client", new_site_client_path(site_id: @site), class: "govuk-button" %>
 <% end %>
 
+<% if @site.policies.any? %>
+  <table class="govuk-table">
+    <caption class="govuk-table__caption">List of attached policies</caption>
+    <tbody class="govuk-table__body">
+      <% @site.policies.each do |policy| %>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell"><%= policy.name %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>
+
 <% if @site.clients.any? %>
   <table class="govuk-table">
     <caption class="govuk-table__caption">List of Authorised Clients</caption>

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -12,6 +12,10 @@
   </div>
 </dl>
 
+<% if can? :manage, Site %>
+  <%= link_to "Attach policies", site_policies_path(site_id: @site), class: "govuk-button" %>
+<% end %>
+
 <% if can? :create, Client %>
   <%= link_to "Add client", new_site_client_path(site_id: @site), class: "govuk-button" %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,9 @@ Rails.application.routes.draw do
     resources :clients
   end
 
+  get "/sites/:id/policies", to: "sites#policies", as: "site_policies"
+  post "/sites/:id/policies", to: "sites#attach_policies", as: "attach_site_policies"
+
   resources :policies do
     resources :rules
     resources :responses

--- a/spec/acceptance/sites/attach_policies_spec.rb
+++ b/spec/acceptance/sites/attach_policies_spec.rb
@@ -31,7 +31,7 @@ describe "attach policies to a site", type: :feature do
       let!(:second_policy) { create :policy, name: "Second Policy" }
       let!(:third_policy) { create :policy, name: "Third Policy" }
 
-      it "does not allow attaching policies to a site" do
+      it "does allow attaching policies to a site" do
         visit "/sites"
 
         click_on "Manage", match: :first
@@ -52,6 +52,30 @@ describe "attach policies to a site", type: :feature do
         expect(page).to have_content("First Policy")
         expect(page).to have_content("Second Policy")
         expect(page).to_not have_content("Third Policy")
+      end
+
+      context "when no policies are attached to a site" do
+        it "does not show any attached policies" do
+          visit "/sites/#{site.id}"
+
+          click_on "Attach policies"
+
+          check "First Policy", allow_label_click: true
+
+          click_on "Attach"
+
+          expect(page).to have_content("Successfully attached policies to the site.")
+
+          click_on "Attach policies"
+
+          uncheck "First Policy"
+
+          click_on "Attach"
+
+          expect(page).to_not have_content("List of attached policies")
+          expect(page).to_not have_content("First Policy")
+
+        end
       end
     end
   end

--- a/spec/acceptance/sites/attach_policies_spec.rb
+++ b/spec/acceptance/sites/attach_policies_spec.rb
@@ -21,8 +21,8 @@ describe "attach policies to a site", type: :feature do
 
         expect(current_path).to eq("/sites/#{site.id}/policies")
 
-        check "policy_#{first_policy.id}", allow_label_click: true
-        check "policy_#{second_policy.id}", allow_label_click: true
+        check "First Policy", allow_label_click: true
+        check "Second Policy", allow_label_click: true
 
         click_on "Attach"
 

--- a/spec/acceptance/sites/attach_policies_spec.rb
+++ b/spec/acceptance/sites/attach_policies_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+describe "attach policies to a site", type: :feature do
+  context "when the user is an editor" do
+    before do
+      login_as create(:user, :editor)
+    end
+
+    context "when both site and policies exists" do
+      let!(:site) { create :site }
+      let!(:first_policy) { create :policy, name: "First Policy" }
+      let!(:second_policy) { create :policy, name: "Second Policy" }
+      let!(:third_policy) { create :policy, name: "Third Policy" }
+
+      it "does not allow attaching policies to a site" do
+        visit "/sites"
+
+        click_on "Manage", match: :first
+
+        click_on "Attach policies"
+
+        expect(current_path).to eq("/sites/#{site.id}/policies")
+
+        check "First Policy", allow_label_click: true
+        check "Second Policy", allow_label_click: true
+
+        click_on "Attach"
+
+        expect(current_path).to eq("/sites/#{site.id}")
+
+        expect(page).to have_content("List of attached policies")
+        expect(page).to have_content("First Policy")
+        expect(page).to have_content("Second Policy")
+        expect(page).to_not have_content("Third Policy")
+      end
+    end
+  end
+
+  # context "when the user is a reader" do
+  #   before do
+  #     login_as create(:user, :reader)
+  #   end
+
+  #   context "when both site and policy exists" do
+  #     let!(:site) { create :site }
+  #     let!(:policy) { create :policy }
+
+  #     it "does not allow attaching policies to a site" do
+  #       visit "/sites"
+
+  #       click_on "View", match: :first
+
+  #       expect(page).to_not have_content "Attach policies"
+  #     end
+  #   end
+  # end
+end

--- a/spec/acceptance/sites/attach_policies_spec.rb
+++ b/spec/acceptance/sites/attach_policies_spec.rb
@@ -1,6 +1,25 @@
 require "rails_helper"
 
 describe "attach policies to a site", type: :feature do
+  context "when the user is a reader" do
+    before do
+      login_as create(:user, :reader)
+    end
+
+    context "when both site and policy exists" do
+      let!(:site) { create :site }
+      let!(:policy) { create :policy }
+
+      it "does not allow attaching policies to a site" do
+        visit "/sites"
+
+        click_on "View", match: :first
+
+        expect(page).to_not have_content "Attach policies"
+      end
+    end
+  end
+
   context "when the user is an editor" do
     before do
       login_as create(:user, :editor)
@@ -36,23 +55,4 @@ describe "attach policies to a site", type: :feature do
       end
     end
   end
-
-  # context "when the user is a reader" do
-  #   before do
-  #     login_as create(:user, :reader)
-  #   end
-
-  #   context "when both site and policy exists" do
-  #     let!(:site) { create :site }
-  #     let!(:policy) { create :policy }
-
-  #     it "does not allow attaching policies to a site" do
-  #       visit "/sites"
-
-  #       click_on "View", match: :first
-
-  #       expect(page).to_not have_content "Attach policies"
-  #     end
-  #   end
-  # end
 end

--- a/spec/acceptance/sites/attach_policies_spec.rb
+++ b/spec/acceptance/sites/attach_policies_spec.rb
@@ -54,7 +54,7 @@ describe "attach policies to a site", type: :feature do
         expect(page).to_not have_content("Third Policy")
       end
 
-      context "when no policies are attached to a site" do
+      context "when all policies are detached from a site" do
         it "does not show any attached policies" do
           visit "/sites/#{site.id}"
 
@@ -74,7 +74,24 @@ describe "attach policies to a site", type: :feature do
 
           expect(page).to_not have_content("List of attached policies")
           expect(page).to_not have_content("First Policy")
+        end
+      end
 
+      context "when policies are already attached to a site" do
+        it "does show the policy checked" do
+          visit "/sites/#{site.id}"
+
+          click_on "Attach policies"
+
+          check "First Policy", allow_label_click: true
+
+          click_on "Attach"
+
+          expect(page).to have_content("Successfully attached policies to the site.")
+
+          click_on "Attach policies"
+
+          expect(page).to have_checked_field "First Policy"
         end
       end
     end

--- a/spec/acceptance/sites/attach_policies_spec.rb
+++ b/spec/acceptance/sites/attach_policies_spec.rb
@@ -21,13 +21,14 @@ describe "attach policies to a site", type: :feature do
 
         expect(current_path).to eq("/sites/#{site.id}/policies")
 
-        check "First Policy", allow_label_click: true
-        check "Second Policy", allow_label_click: true
+        check "policy_#{first_policy.id}", allow_label_click: true
+        check "policy_#{second_policy.id}", allow_label_click: true
 
         click_on "Attach"
 
         expect(current_path).to eq("/sites/#{site.id}")
 
+        expect(page).to have_content("Successfully attached policies to the site.")
         expect(page).to have_content("List of attached policies")
         expect(page).to have_content("First Policy")
         expect(page).to have_content("Second Policy")

--- a/spec/acceptance/sites/attach_policies_spec.rb
+++ b/spec/acceptance/sites/attach_policies_spec.rb
@@ -43,55 +43,33 @@ describe "attach policies to a site", type: :feature do
         check "First Policy", allow_label_click: true
         check "Second Policy", allow_label_click: true
 
-        click_on "Attach"
+        click_on "Update"
 
         expect(current_path).to eq("/sites/#{site.id}")
 
-        expect(page).to have_content("Successfully attached policies to the site.")
+        expect(page).to have_content("Successfully updated site policies.")
         expect(page).to have_content("List of attached policies")
         expect(page).to have_content("First Policy")
         expect(page).to have_content("Second Policy")
         expect(page).to_not have_content("Third Policy")
       end
 
-      context "when all policies are detached from a site" do
-        it "does not show any attached policies" do
+      context "when there is a policy attached to a site" do
+        let!(:site) { create :site, policies: [first_policy] }
+
+        it "does allow detaching the policy" do
           visit "/sites/#{site.id}"
-
-          click_on "Attach policies"
-
-          check "First Policy", allow_label_click: true
-
-          click_on "Attach"
-
-          expect(page).to have_content("Successfully attached policies to the site.")
-
-          click_on "Attach policies"
-
-          uncheck "First Policy"
-
-          click_on "Attach"
-
-          expect(page).to_not have_content("List of attached policies")
-          expect(page).to_not have_content("First Policy")
-        end
-      end
-
-      context "when policies are already attached to a site" do
-        it "does show the policy checked" do
-          visit "/sites/#{site.id}"
-
-          click_on "Attach policies"
-
-          check "First Policy", allow_label_click: true
-
-          click_on "Attach"
-
-          expect(page).to have_content("Successfully attached policies to the site.")
 
           click_on "Attach policies"
 
           expect(page).to have_checked_field "First Policy"
+
+          uncheck "First Policy"
+
+          click_on "Update"
+
+          expect(page).to_not have_content("List of attached policies")
+          expect(page).to_not have_content("First Policy")
         end
       end
     end


### PR DESCRIPTION
## Context

- attach policies to sites that show under list of attached policies on site view page
- add ability to remove policies from sites
- show already attached policies when attaching or detaching policies