### PR TITLE
Scope uniqueness validation of cert filename to category

### DIFF
--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -3,7 +3,7 @@ class Certificate < ApplicationRecord
   validates_presence_of :description
   validate :fields_from_certificate_file, on: :create
   validates_inclusion_of :category, in: %w[EAP RADSEC]
-  validates_uniqueness_of :filename
+  validates_uniqueness_of :filename, scope: :category
 
 private
 

--- a/spec/models/certificate_spec.rb
+++ b/spec/models/certificate_spec.rb
@@ -10,7 +10,18 @@ describe Certificate, type: :model do
   it { is_expected.to validate_presence_of :name }
   it { is_expected.to validate_presence_of :description }
   it { is_expected.to validate_uniqueness_of(:name).case_insensitive }
-  it { is_expected.to validate_uniqueness_of(:filename).case_insensitive }
+
+  describe "validate uniquness of filename" do
+    it "rejects duplicate filenames of the same category" do
+      create(:certificate, filename: "server.pem", category: "EAP")
+      expect { create(:certificate, filename: "server.pem", category: "EAP") }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+
+    it "allows duplicate filenames of the different categories" do
+      create(:certificate, filename: "server.pem", category: "RADSEC")
+      expect { create(:certificate, filename: "server.pem", category: "EAP") }.not_to raise_error
+    end
+  end
 
   it "raises an error when fields from certificate file are missing" do
     missing_field = [{ expiry_date: Date.today }, { subject: "may not exist" }].sample


### PR DESCRIPTION
We want to allow the same filename to be used across different
categories (EAP, Radsec). These end up in different directories in S3 so
no danger of overwriting files by accident.

There are no shoulda matchers to make these assertions on the validation.
Change test to actually create two objects for testing.