### PR TITLE
Deploy Radius cluster after a certificate is added or removed

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,6 +18,18 @@ class ApplicationController < ActionController::Base
     end
   end
 
+protected
+
+  def deploy_service
+    UseCases::DeployService.new(
+      ecs_gateway: Gateways::Ecs.new(
+        cluster_name: ENV.fetch("RADIUS_CLUSTER_NAME"),
+        service_name: ENV.fetch("RADIUS_SERVICE_NAME"),
+        aws_config: Rails.application.config.ecs_aws_config,
+      ),
+    ).call
+  end
+
 private
 
   def set_expect_ct_header

--- a/app/controllers/certificates_controller.rb
+++ b/app/controllers/certificates_controller.rb
@@ -1,5 +1,6 @@
 class CertificatesController < ApplicationController
   before_action :set_certificate, only: %i[destroy edit update]
+  after_action :deploy_service, only: %i[create destroy]
 
   def index
     @certificates = Certificate.all

--- a/app/controllers/clients_controller.rb
+++ b/app/controllers/clients_controller.rb
@@ -86,14 +86,4 @@ private
       ),
     )
   end
-
-  def deploy_service
-    UseCases::DeployService.new(
-      ecs_gateway: Gateways::Ecs.new(
-        cluster_name: ENV.fetch("RADIUS_CLUSTER_NAME"),
-        service_name: ENV.fetch("RADIUS_SERVICE_NAME"),
-        aws_config: Rails.application.config.ecs_aws_config,
-      ),
-    ).call
-  end
 end


### PR DESCRIPTION
Move the deployment logic to the Application controller where it can be
shared.