### PR TITLE
Deploy both internet facing and internal radius services

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,6 +28,14 @@ protected
         aws_config: Rails.application.config.ecs_aws_config,
       ),
     ).call
+
+    UseCases::DeployService.new(
+      ecs_gateway: Gateways::Ecs.new(
+        cluster_name: ENV.fetch("RADIUS_CLUSTER_NAME"),
+        service_name: ENV.fetch("RADIUS_INTERNAL_SERVICE_NAME"),
+        aws_config: Rails.application.config.ecs_aws_config,
+      ),
+    ).call
   end
 
 private


### PR DESCRIPTION
Currently we only deploy the internet facing service when changes are
made in the admin. This will deploy the internal service as well.