### PR TITLE
Sentry environment non-production

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -12,3 +12,4 @@ DB_USER=root
 DB_PASS=root
 SECRET_KEY_BASE=fakekeybase
 DB_PORT=3306
+SENTRY_DSN=test.test

--- a/.env.test
+++ b/.env.test
@@ -12,3 +12,4 @@ DB_USER=root
 DB_PASS=root
 SECRET_KEY_BASE=fakekeybase
 DB_PORT=3306
+SENTRY_DSN=test.test

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ ARG DB_NAME=root
 ARG BUNDLE_WITHOUT=""
 ARG BUNDLE_INSTALL_FLAGS=""
 ARG RUN_PRECOMPILATION=true
+ARG SENTRY_DSN=""
 
 # required for certain linting tools that read files, such as erb-lint
 ENV LANG='C.UTF-8' \

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,9 +1,11 @@
-Sentry.init do |config|
-  config.dsn = ENV.fetch("SENTRY_DSN")
-  config.breadcrumbs_logger = %i[active_support_logger http_logger]
+if %w[production].include?(ENV.fetch("RACK_ENV"))
+  Sentry.init do |config|
+    config.dsn = ENV.fetch("SENTRY_DSN")
+    config.breadcrumbs_logger = %i[active_support_logger http_logger]
 
-  # Set tracesSampleRate to 1.0 to capture 100%
-  # of transactions for performance monitoring.
-  # We recommend adjusting this value in production
-  config.traces_sample_rate = 1.0
+    # Set tracesSampleRate to 1.0 to capture 100%
+    # of transactions for performance monitoring.
+    # We recommend adjusting this value in production
+    config.traces_sample_rate = 1.0
+  end
 end


### PR DESCRIPTION
Add SENTRY DSN values to dockerfile and .env files 
This is required when the tests run.
Only instantiate Sentry in production. 
Exclude from tests and local development from reporting errors