### PR TITLE
Boot admin portal in background

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ db-setup: start-db
 	$(DOCKER_COMPOSE) run --rm app ./bin/rails db:drop db:create db:schema:load
 
 serve: stop start-db
-	$(DOCKER_COMPOSE) up app
+	$(DOCKER_COMPOSE) up -d app
 
 run: serve
 


### PR DESCRIPTION
This doesn't need to be run in the foreground. Run in background so it
doesn't block any processes that follow.