### PR TITLE
Allow local stack testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ db-setup: start-db
 	$(DOCKER_COMPOSE) run --rm app ./bin/rails db:drop db:create db:schema:load
 
 serve: stop start-db
-	$(DOCKER_COMPOSE) up app
+	$(DOCKER_COMPOSE) up -d app
 
 run: serve
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
       - "3306:3306"
     volumes:
       - datavolume:/var/lib/mysql
+    networks:
+      - adminnet
 
   app:
     build:
@@ -30,7 +32,13 @@ services:
     ports:
       - "3000:3000"
     env_file: .env.${ENV}
+    networks:
+      - adminnet
 
 volumes:
   node_modules:
   datavolume:
+
+networks:
+  adminnet:
+    name: adminnet

--- a/scripts/wait_for_db.sh
+++ b/scripts/wait_for_db.sh
@@ -8,6 +8,3 @@ do
   printf "."
   sleep 1
 done
-
-env
-docker ps


### PR DESCRIPTION
Boot admin portal in background
This doesn't need to be run in the foreground. Run in background so it
doesn't block any processes that follow.

Run the admin service in a shared network 
This is required because the servers will connect to the admin db to
read policy data.