### PR TITLE
Refactor Site and Policies relations

### DIFF
--- a/app/models/policies_sites.rb
+++ b/app/models/policies_sites.rb
@@ -1,3 +1,0 @@
-class PoliciesSites < ApplicationRecord
-  audited
-end

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -5,7 +5,9 @@ class Policy < ApplicationRecord
 
   has_many :rules, dependent: :destroy
   has_many :responses, dependent: :destroy
-  has_and_belongs_to_many :sites
+
+  has_many :site_policy
+  has_many :sites, through: :site_policy
 
   audited
 end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -2,7 +2,8 @@ class Site < ApplicationRecord
   validates :name, presence: true, uniqueness: { case_sensitive: false }
 
   has_many :clients, dependent: :destroy
-  has_and_belongs_to_many :policies, -> { distinct }
+  has_many :site_policy
+  has_many :policies, through: :site_policy
 
   audited
 

--- a/app/models/site_policy.rb
+++ b/app/models/site_policy.rb
@@ -1,0 +1,6 @@
+class SitePolicy < ApplicationRecord
+  belongs_to :site
+  belongs_to :policy
+
+  audited
+end

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -43,7 +43,7 @@
 
 <% if @site.clients.any? %>
   <table class="govuk-table">
-    <caption class="govuk-table__caption">List of Authorised Clients</caption>
+    <h3 class="govuk-heading-m">List of Authorised Clients</h3>
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th scope="col" class="govuk-table__header">IP / Subnet CIDR</th>

--- a/db/migrate/20210908130546_create_site_policy.rb
+++ b/db/migrate/20210908130546_create_site_policy.rb
@@ -1,0 +1,13 @@
+class CreateSitePolicy < ActiveRecord::Migration[6.1]
+  def change
+    create_table :site_policies do |t|
+      t.bigint :site_id
+      t.bigint :policy_id
+      t.integer :priority
+
+      t.timestamps
+    end
+
+    drop_table :policies_sites
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_06_140856) do
+ActiveRecord::Schema.define(version: 2021_09_08_130546) do
 
   create_table "audits", charset: "utf8", force: :cascade do |t|
     t.integer "auditable_id"
@@ -71,14 +71,6 @@ ActiveRecord::Schema.define(version: 2021_09_06_140856) do
     t.boolean "fallback", null: false
   end
 
-  create_table "policies_sites", charset: "utf8", force: :cascade do |t|
-    t.bigint "policy_id", null: false
-    t.bigint "site_id", null: false
-    t.integer "priority"
-    t.index ["policy_id"], name: "index_policies_sites_on_policy_id"
-    t.index ["site_id"], name: "index_policies_sites_on_site_id"
-  end
-
   create_table "responses", charset: "utf8", force: :cascade do |t|
     t.string "response_attribute", null: false
     t.string "value", null: false
@@ -98,6 +90,14 @@ ActiveRecord::Schema.define(version: 2021_09_06_140856) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["policy_id"], name: "index_rules_on_policy_id"
+  end
+
+  create_table "site_policies", charset: "utf8", force: :cascade do |t|
+    t.bigint "site_id"
+    t.bigint "policy_id"
+    t.integer "priority"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "sites", charset: "utf8", force: :cascade do |t|

--- a/spec/factories/site_policy.rb
+++ b/spec/factories/site_policy.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :policies_sites do
+  factory :site_policy do
     site_id { FactoryBot.create(:site).id }
     policy_id { FactoryBot.create(:policy).id }
   end

--- a/spec/models/policy_spec.rb
+++ b/spec/models/policy_spec.rb
@@ -12,5 +12,6 @@ describe Policy, type: :model do
   it { is_expected.to validate_uniqueness_of(:name).case_insensitive }
   it { is_expected.to have_many(:rules) }
   it { is_expected.to have_many(:responses) }
-  it { is_expected.to have_and_belong_to_many(:sites) }
+  it { is_expected.to have_many(:site_policy) }
+  it { is_expected.to have_many(:sites) }
 end

--- a/spec/models/site_policy_spec.rb
+++ b/spec/models/site_policy_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
-RSpec.describe PoliciesSites, type: :model do
-  subject { build :policies_sites }
+RSpec.describe SitePolicy, type: :model do
+  subject { build :site_policy }
 
   it "has a valid factory" do
     expect(subject).to be_valid

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe Site, type: :model do
   it { is_expected.to validate_presence_of :name }
   it { is_expected.to validate_uniqueness_of(:name).case_insensitive }
   it { is_expected.to have_many(:clients) }
-  it { is_expected.to have_and_belong_to_many(:policies) }
+  it { is_expected.to have_many(:site_policy) }
+  it { is_expected.to have_many(:policies) }
 
   it "responds to #fallback_policy" do
     expect(subject.fallback_policy).to be_nil


### PR DESCRIPTION
- Use `has_many through::site_policy` to establish the relation between `Sites` and `Policies` this will allow more elegant queries when we need to update `SitePolicies`
- Replace `PoliciesSites` model with `SitePolicies` 
- Drop PoliciesSites joint table and create a new `SitePolicies` table