### PR TITLE
Add update_rule_count

### DIFF
--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -8,7 +8,7 @@ class Rule < ApplicationRecord
 
   audited
 
-  private
+private
 
   def update_rule_count
     policy.update_attribute(:rule_count, policy.rules.count)

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -1,8 +1,16 @@
 class Rule < ApplicationRecord
   belongs_to :policy
 
+  after_save :update_rule_count
+
   validates_presence_of :request_attribute, :operator, :value
   validates_inclusion_of :operator, in: %w[equals contains]
 
   audited
+
+  private
+
+  def update_rule_count
+    policy.update_attribute(:rule_count, policy.rules.count)
+  end
 end

--- a/spec/models/rule_spec.rb
+++ b/spec/models/rule_spec.rb
@@ -16,4 +16,13 @@ describe Rule, type: :model do
     subject.operator = "somethinginvalid"
     expect(subject).not_to be_valid
   end
+
+  it "perists the amount of rules when a policy is saved" do
+    policy = create(:policy)
+
+    create(:rule, policy: policy)
+    create(:rule, policy: policy)
+
+    expect(Rule.first.policy.rule_count).to eq(2)
+  end
 end


### PR DESCRIPTION
Each time a rule is saved, it will update the policy rule count.
This value is required by the policy engine, and we do not want
to compute it at runtime each time a authentication happens for
performance reasons.