### PR TITLE
Reduce the amount of data loaded for policy engine performance testing

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,47 +2,29 @@ def ip_range
   sprintf("%d.%d.%d.%d", rand(256), rand(256), rand(256), rand(256))
 end
 
+p "creating policies"
+3000.times do |p|
+  policy = Policy.create!(name: "Policy: #{p}", description: "Some policy description", fallback: false)
+
+  5.times do |_r|
+    policy.rules.create!(request_attribute: "Aruba-AP-Group", operator: "equals", value: "SetMeUp-C7:7D:EE#{p}-#{_r}")
+  end
+
+  5.times do |r|
+    policy.responses.create!(response_attribute: "Reply-Message", value: "Hello! #{r} #{p}")
+  end
+end
+
+p "creating policies"
+500.times do |s|
+  fallback_policy = Policy.create!(name: "Fallback Policy: #{s}", description: "Some policy description", fallback: true)
+  fallback_response = Response.create!(response_attribute: "Reply-Message", value: "Oh no #{s}")
+  fallback_policy.responses << fallback_response
+end
+
+p "creating sites"
 2000.times do |s|
   site = Site.create!(name: "Test site #{s}")
-
-  fallback_policy = Policy.create!(
-    name: "Fallback Policy: #{s}",
-    description: "Some policy description",
-    fallback: true,
-  )
-
-  fallback_response = Response.create!(
-    response_attribute: "Reply-Message",
-    value: "Oh no",
-  )
-
-  fallback_policy.responses << fallback_response
-
-  5.times do |p|
-    policy = Policy.create!(
-      name: "Policy: #{p} #{s}",
-      description: "Some policy description",
-      fallback: false,
-    )
-
-    5.times do |_r|
-      policy.rules.create!(
-        request_attribute: "Aruba-AP-Group",
-        operator: "equals",
-        value: "SetMeUp-C7:7D:EE",
-      )
-    end
-
-    5.times do |r|
-      policy.responses.create!(
-        response_attribute: "Reply-Message",
-        value: "Hello! #{r} #{s}",
-      )
-    end
-
-    site.policies << policy
-    site.policies << fallback_policy
-  end
 
   20.times do |c|
     Client.create!(
@@ -53,4 +35,10 @@ end
   rescue StandardError
     retry
   end
+end
+  
+p "assigning policies to sites"
+Site.all.each do |site|
+  site.policies << Policy.select(:id).sample
+  site.policies << Policy.where(fallback: true).select(:id).sample
 end

--- a/scripts/seed.sh
+++ b/scripts/seed.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 source ./scripts/aws_helpers.sh
 
 seed() {
-  local seed_command="./bin/rails db:seed"
+  local seed_command="./bin/rails db:reset db:seed"
   local docker_service_name="admin"
   local cluster_name service_name task_definition docker_service_name
 


### PR DESCRIPTION
Instead of 10k policies, we will create only 3k policies. It is
expected that policies will be shared in production.

This more closely reflects real world usage.

Temporarily run a db:reset before loading this new data.