### PR TITLE
Bugfix: Display error when submitting custom rules/responses

### DIFF
--- a/app/views/rules/_form.html.erb
+++ b/app/views/rules/_form.html.erb
@@ -21,8 +21,10 @@
         </div>
       </div>
       <div class="govuk-radios__item">
+      <%= params.inspect %><br />
+      <%= rule.inspect %>
         <%= f.radio_button "request-attribute", "custom", {
-            checked: !f.object.new_record? && !AttributesHelper.requests.include?(rule.request_attribute),
+            checked: params.dig(:rule, :'request-attribute') == "custom" || (!f.object.new_record? && !AttributesHelper.requests.include?(rule.request_attribute)),
             class: "govuk-radios__input",
             id: "request-attribute-2",
             'data-aria-controls': "conditional-request-attribute-2"

--- a/app/views/shared/_response_form.html.erb
+++ b/app/views/shared/_response_form.html.erb
@@ -22,7 +22,7 @@
       </div>
       <div class="govuk-radios__item">
         <%= f.radio_button "response-attribute", "custom", {
-            checked: !f.object.new_record? && !AttributesHelper.responses.include?(response.response_attribute),
+            checked: params.dig(response.model_name.element, :'response-attribute') == "custom" || (!f.object.new_record? && !AttributesHelper.responses.include?(response.response_attribute)),
             class: "govuk-radios__input",
             id: "response-attribute-2",
             'data-aria-controls': "conditional-response-attribute-2"

--- a/spec/acceptance/policy/rules/create_rules_spec.rb
+++ b/spec/acceptance/policy/rules/create_rules_spec.rb
@@ -46,6 +46,26 @@ describe "create rules", type: :feature do
         expect(page).to have_content("Successfully created rule.")
       end
 
+      it "displays error if form cannot be submitted multiple times" do
+        visit "/policies/#{policy.id}"
+
+        click_on "Add rule"
+
+        choose "Custom"
+        fill_in "custom-request-attribute", with: "Invalid-Attribute"
+        select "equals", from: "Operator"
+        fill_in "Value", with: "Invalid-Value"
+
+        click_on "Create"
+
+        expect(page).to have_content("There is a problem")
+
+        click_on "Create"
+
+        expect(page).to have_checked_field("Custom")
+        expect(page).to have_content("There is a problem")
+      end
+
       it "displays error if form cannot be submitted" do
         visit new_policy_rule_path(policy_id: policy)
 

--- a/spec/support/shared_examples/responses/create_new_responses.rb
+++ b/spec/support/shared_examples/responses/create_new_responses.rb
@@ -52,6 +52,25 @@ RSpec.shared_examples "new response creation" do |domain, response|
         expect_audit_log_entry_for(editor.email, "create", "Response")
       end
 
+      it "displays error if form cannot be submitted multiple times" do
+        visit "/#{domain.to_s.pluralize}/#{created_domain.id}"
+
+        click_on "Add response"
+
+        choose "Custom"
+        fill_in "custom-response-attribute", with: "Invalid-Attribute"
+        fill_in "Value", with: "Invalid-Value"
+
+        click_on "Create"
+
+        expect(page).to have_content("There is a problem")
+
+        click_on "Create"
+
+        expect(page).to have_checked_field("Custom")
+        expect(page).to have_content("There is a problem")
+      end
+
       it "displays an error if form cannot be submitted" do
         visit "/#{domain.to_s.pluralize}/#{created_domain.id}/#{response.to_s.pluralize}/new"
 


### PR DESCRIPTION
## Context

- Ensure radio button is selected when form is submitted more than once with an invalid rule/response