### PR TITLE
Allow larger values to be entered in the Policy Engine

### DIFF
--- a/db/migrate/20211109082249_update_attribute_value_type.rb
+++ b/db/migrate/20211109082249_update_attribute_value_type.rb
@@ -1,0 +1,15 @@
+class UpdateAttributeValueType < ActiveRecord::Migration[6.1]
+  def change
+    tables = %w[
+      rules
+      responses
+    ]
+
+    tables.each do |table|
+      change_table table do |t|
+        t.change :value, :text, null: false
+        t.change :value, :text, null: false
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_28_103519) do
+ActiveRecord::Schema.define(version: 2021_11_09_082249) do
 
   create_table "audits", charset: "utf8", force: :cascade do |t|
     t.integer "auditable_id"
@@ -74,7 +74,7 @@ ActiveRecord::Schema.define(version: 2021_10_28_103519) do
 
   create_table "responses", charset: "utf8", force: :cascade do |t|
     t.string "response_attribute", null: false
-    t.string "value", null: false
+    t.text "value", null: false
     t.datetime "created_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.datetime "updated_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.bigint "mac_authentication_bypass_id"
@@ -85,7 +85,7 @@ ActiveRecord::Schema.define(version: 2021_10_28_103519) do
 
   create_table "rules", charset: "utf8", force: :cascade do |t|
     t.string "operator", null: false
-    t.string "value", null: false
+    t.text "value", null: false
     t.bigint "policy_id", null: false
     t.string "request_attribute", null: false
     t.datetime "created_at", default: -> { "CURRENT_TIMESTAMP" }, null: false


### PR DESCRIPTION
Currently the value fields for both request and responses of the
policy engine is defined as type varchar(255).
This restricts the length of the values that can be entered.
There will be scenarios where larger values need to be entered.

Update the schema for these columns to text to allow this.