### PR TITLE
Remove trailing/leading whitespace from attribute keys

### DIFF
--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -1,4 +1,6 @@
 class Response < ApplicationRecord
+  before_validation :format_response_attribute
+
   validates_presence_of :response_attribute, :value
   validate :validate_response, on: %i[create update]
 
@@ -14,5 +16,9 @@ private
     unless result.fetch(:success)
       errors.add(:response_attribute, result.fetch(:message))
     end
+  end
+
+  def format_response_attribute
+    response_attribute.strip! if response_attribute
   end
 end

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -1,6 +1,7 @@
 class Rule < ApplicationRecord
   belongs_to :policy
 
+  before_validation :format_request_attribute
   after_save :update_rule_count
 
   validates_presence_of :request_attribute, :operator, :value
@@ -19,6 +20,10 @@ private
     unless result.fetch(:success)
       errors.add(:request_attribute, result.fetch(:message))
     end
+  end
+
+  def format_request_attribute
+    request_attribute.strip! if request_attribute
   end
 
   def update_rule_count

--- a/spec/models/mac_authentication_bypass_response_spec.rb
+++ b/spec/models/mac_authentication_bypass_response_spec.rb
@@ -29,6 +29,14 @@ describe MabResponse, type: :model do
     expect(result).to be_invalid
   end
 
+  it "validates the response attribute with trailing whitespace" do
+    result = build(:mab_response, response_attribute: " User-Name ", value: "Foo")
+
+    result.valid?
+
+    expect(result.response_attribute).to eq("User-Name")
+  end
+
   it "validates an updated response attribute" do
     editable_response = create(:mab_response)
 

--- a/spec/models/policy_response_spec.rb
+++ b/spec/models/policy_response_spec.rb
@@ -29,6 +29,14 @@ describe PolicyResponse, type: :model do
     expect(result).to be_invalid
   end
 
+  it "validates the response attribute with trailing whitespace" do
+    result = build(:policy_response, response_attribute: " User-Name ", value: "Foo")
+
+    result.valid?
+
+    expect(result.response_attribute).to eq("User-Name")
+  end
+
   it "validates an updated response attribute" do
     editable_response = create(:policy_response)
 

--- a/spec/models/rule_spec.rb
+++ b/spec/models/rule_spec.rb
@@ -29,6 +29,14 @@ describe Rule, type: :model do
     expect(result).to be_invalid
   end
 
+  it "validates the request attribute with trailing whitespace" do
+    result = build(:rule, request_attribute: " User-Name ", value: "Foo")
+
+    result.valid?
+
+    expect(result.request_attribute).to eq("User-Name")
+  end
+
   it "validates an updated request attribute" do
     editable_rule = create(:rule)
 


### PR DESCRIPTION
## Context

- Remove trailing/leading whitespace from request/response attribute names