### PR TITLE
The old wording just stated "Address"

### DIFF
--- a/app/views/mac_authentication_bypasses/_form.html.erb
+++ b/app/views/mac_authentication_bypasses/_form.html.erb
@@ -1,6 +1,6 @@
 <%= form_with model: mac_authentication_bypass, local: true do |f| %>
   <div class="govuk-form-group <%= field_error(f.object, :address) %>">
-    <%= f.label :address, class: "govuk-label" %>
+    <%= f.label :address, "MAC Address", class: "govuk-label" %>
     <div id="address-hint" class="govuk-hint">
       Must be lowercase and separated by a dash.<br />
       For example: aa-bb-cc-77-88-99

--- a/app/views/mac_authentication_bypasses/index.html.erb
+++ b/app/views/mac_authentication_bypasses/index.html.erb
@@ -9,7 +9,7 @@
     <caption class="govuk-table__caption govuk-visually-hidden">List of MAC Authentication Bypasses</caption>
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
-        <th scope="col" class="govuk-table__header">Address</th>
+        <th scope="col" class="govuk-table__header">MAC Address</th>
         <th scope="col" class="govuk-table__header">Name</th>
         <th scope="col" class="govuk-table__header">Description</th>
         <th scope="col" class="govuk-table__header">


### PR DESCRIPTION
Needs to say the full domain language used, i.e. "MAC Address"