### PR TITLE
Validate uniqueness of request/response attributes

### DIFF
--- a/app/models/mab_response.rb
+++ b/app/models/mab_response.rb
@@ -1,3 +1,13 @@
 class MabResponse < Response
   belongs_to :mac_authentication_bypass
+
+  validate :validate_uniqueness_of_response_attribute, on: %i[create update]
+
+private
+
+  def validate_uniqueness_of_response_attribute
+    return if response_attribute.blank? || mac_authentication_bypass.nil?
+
+    errors.add(:response_attribute, "has already been added for this policy") if mac_authentication_bypass.responses.where(response_attribute: response_attribute).any?
+  end
 end

--- a/app/models/policy_response.rb
+++ b/app/models/policy_response.rb
@@ -1,3 +1,13 @@
 class PolicyResponse < Response
   belongs_to :policy
+
+  validate :validate_uniqueness_of_response_attribute, on: %i[create update]
+
+private
+
+  def validate_uniqueness_of_response_attribute
+    return if response_attribute.blank? || policy.nil?
+
+    errors.add(:response_attribute, "has already been added for this policy") if policy.responses.where(response_attribute: response_attribute).any?
+  end
 end

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -6,7 +6,7 @@ class Rule < ApplicationRecord
 
   validates_presence_of :request_attribute, :operator, :value
   validates_inclusion_of :operator, in: %w[equals contains]
-  validate :validate_uniqueness_of_request_attribute, on: %i[create]
+  validate :validate_uniqueness_of_request_attribute, on: %i[create update]
   validate :validate_rule, on: %i[create update]
 
   audited
@@ -16,7 +16,7 @@ private
   def validate_uniqueness_of_request_attribute
     return if request_attribute.blank? || policy.nil?
 
-    errors.add(:request_attribute, " has already been added for this policy") if policy.rules.where(request_attribute: request_attribute).any?
+    errors.add(:request_attribute, "has already been added for this policy") if policy.rules.where(request_attribute: request_attribute).any?
   end
 
   def validate_rule

--- a/spec/acceptance/policy/rules/update_rules_spec.rb
+++ b/spec/acceptance/policy/rules/update_rules_spec.rb
@@ -47,18 +47,18 @@ describe "update rules", type: :feature do
       expect(page).to have_select("Operator", text: rule.operator)
       expect(page).to have_field("Value", with: rule.value)
 
-      select "Reply-Message", from: "request-attribute"
+      select "User-Name", from: "request-attribute"
       select "contains", from: "Operator"
-      fill_in "Value", with: "Hi hi"
+      fill_in "Value", with: "Bob"
 
       click_on "Update"
 
       expect(current_path).to eq("/policies/#{policy.id}")
 
       expect(page).to have_content("Successfully updated rule.")
-      expect(page).to have_content "Reply-Message"
+      expect(page).to have_content "User-Name"
       expect(page).to have_content "contains"
-      expect(page).to have_content "Hi hi"
+      expect(page).to have_content "Bob"
 
       expect_audit_log_entry_for(editor.email, "update", "Rule")
     end

--- a/spec/models/mac_authentication_bypass_response_spec.rb
+++ b/spec/models/mac_authentication_bypass_response_spec.rb
@@ -40,10 +40,31 @@ describe MabResponse, type: :model do
   it "validates an updated response attribute" do
     editable_response = create(:mab_response)
 
-    expect(editable_response).to be_valid
+    expect(editable_response).to be_truthy
 
     editable_response.update(response_attribute: "Invalid-Attribute")
 
     expect(editable_response).to be_invalid
+  end
+
+  it "validates the uniquness of response attribute per policy when creating" do
+    mab = create(:mac_authentication_bypass)
+
+    mab_response = create(:mab_response, mac_authentication_bypass: mab, response_attribute: "User-Name", value: "Bob")
+
+    expect(mab_response).to be_truthy
+
+    duplicate_mab_response = build(:mab_response, mac_authentication_bypass: mab, response_attribute: "User-Name", value: "Bill")
+    expect(duplicate_mab_response).to be_invalid
+  end
+
+  it "validates the uniqueness of the response attribute per policy when updating" do
+    mab = create(:mac_authentication_bypass)
+
+    first_mab_response = create(:mab_response, mac_authentication_bypass: mab, response_attribute: "User-Name", value: "Bob")
+    second_mab_response = create(:mab_response, mac_authentication_bypass: mab, response_attribute: "Class", value: "Something")
+
+    expect(first_mab_response.update(response_attribute: "User-Name")).to be false
+    expect(first_mab_response.errors.full_messages_for(:response_attribute)).to include("Response attribute has already been added for this policy")
   end
 end

--- a/spec/models/mac_authentication_bypass_response_spec.rb
+++ b/spec/models/mac_authentication_bypass_response_spec.rb
@@ -62,7 +62,7 @@ describe MabResponse, type: :model do
     mab = create(:mac_authentication_bypass)
 
     first_mab_response = create(:mab_response, mac_authentication_bypass: mab, response_attribute: "User-Name", value: "Bob")
-    second_mab_response = create(:mab_response, mac_authentication_bypass: mab, response_attribute: "Class", value: "Something")
+    create(:mab_response, mac_authentication_bypass: mab, response_attribute: "Class", value: "Something")
 
     expect(first_mab_response.update(response_attribute: "User-Name")).to be false
     expect(first_mab_response.errors.full_messages_for(:response_attribute)).to include("Response attribute has already been added for this policy")

--- a/spec/models/policy_response_spec.rb
+++ b/spec/models/policy_response_spec.rb
@@ -62,7 +62,7 @@ describe PolicyResponse, type: :model do
     policy = create(:policy)
 
     first_policy_response = create(:policy_response, policy: policy, response_attribute: "User-Name", value: "Bob")
-    second_policy_response = create(:policy_response, policy: policy, response_attribute: "Class", value: "Something")
+    create(:policy_response, policy: policy, response_attribute: "Class", value: "Something")
 
     expect(first_policy_response.update(response_attribute: "User-Name")).to be false
     expect(first_policy_response.errors.full_messages_for(:response_attribute)).to include("Response attribute has already been added for this policy")

--- a/spec/models/policy_response_spec.rb
+++ b/spec/models/policy_response_spec.rb
@@ -40,10 +40,31 @@ describe PolicyResponse, type: :model do
   it "validates an updated response attribute" do
     editable_response = create(:policy_response)
 
-    expect(editable_response).to be_valid
+    expect(editable_response).to be_truthy
 
     editable_response.update(response_attribute: "Invalid-Attribute")
 
     expect(editable_response).to be_invalid
+  end
+
+  it "validates the uniquness of response attribute per policy when creating" do
+    policy = create(:policy)
+
+    policy_response = create(:policy_response, policy: policy, response_attribute: "User-Name", value: "Bob")
+
+    expect(policy_response).to be_truthy
+
+    duplicate_policy_response = build(:policy_response, policy: policy, response_attribute: "User-Name", value: "Bill")
+    expect(duplicate_policy_response).to be_invalid
+  end
+
+  it "validates the uniqueness of the response attribute per policy when updating" do
+    policy = create(:policy)
+
+    first_policy_response = create(:policy_response, policy: policy, response_attribute: "User-Name", value: "Bob")
+    second_policy_response = create(:policy_response, policy: policy, response_attribute: "Class", value: "Something")
+
+    expect(first_policy_response.update(response_attribute: "User-Name")).to be false
+    expect(first_policy_response.errors.full_messages_for(:response_attribute)).to include("Response attribute has already been added for this policy")
   end
 end

--- a/spec/models/rule_spec.rb
+++ b/spec/models/rule_spec.rb
@@ -76,7 +76,7 @@ describe Rule, type: :model do
     policy = create(:policy)
 
     first_rule = create(:rule, policy: policy, request_attribute: "User-Name", value: "Bob")
-    second_rule = create(:rule, policy: policy, request_attribute: "Class", value: "Something")
+    create(:rule, policy: policy, request_attribute: "Class", value: "Something")
 
     expect(first_rule.update(request_attribute: "User-Name")).to be false
     expect(first_rule.errors.full_messages_for(:request_attribute)).to include("Request attribute has already been added for this policy")

--- a/spec/models/rule_spec.rb
+++ b/spec/models/rule_spec.rb
@@ -55,9 +55,20 @@ describe Rule, type: :model do
   it "perists the amount of rules when a policy is saved" do
     policy = create(:policy)
 
-    create(:rule, policy: policy)
-    create(:rule, policy: policy)
+    create(:rule, request_attribute: "User-Name", policy: policy)
+    create(:rule, request_attribute: "User-Password", policy: policy)
 
     expect(Rule.first.policy.rule_count).to eq(2)
+  end
+
+  it "validates the uniquness of request attribute per policy" do
+    policy = create(:policy)
+
+    rule = create(:rule, policy: policy, request_attribute: "User-Name", value: "Bob")
+
+    expect(rule).to be_truthy
+
+    duplicate_rule = build(:rule, policy: policy, request_attribute: "User-Name", value: "Bill")
+    expect(duplicate_rule).to be_invalid
   end
 end

--- a/spec/models/rule_spec.rb
+++ b/spec/models/rule_spec.rb
@@ -40,7 +40,7 @@ describe Rule, type: :model do
   it "validates an updated request attribute" do
     editable_rule = create(:rule)
 
-    expect(editable_rule).to be_valid
+    expect(editable_rule).to be_truthy
 
     editable_rule.update(request_attribute: "Invalid-Attribute")
 
@@ -61,7 +61,7 @@ describe Rule, type: :model do
     expect(Rule.first.policy.rule_count).to eq(2)
   end
 
-  it "validates the uniquness of request attribute per policy" do
+  it "validates the uniquness of request attribute per policy when creating" do
     policy = create(:policy)
 
     rule = create(:rule, policy: policy, request_attribute: "User-Name", value: "Bob")
@@ -70,5 +70,15 @@ describe Rule, type: :model do
 
     duplicate_rule = build(:rule, policy: policy, request_attribute: "User-Name", value: "Bill")
     expect(duplicate_rule).to be_invalid
+  end
+
+  it "validates the uniqueness of the request attribute per policy when updating" do
+    policy = create(:policy)
+
+    first_rule = create(:rule, policy: policy, request_attribute: "User-Name", value: "Bob")
+    second_rule = create(:rule, policy: policy, request_attribute: "Class", value: "Something")
+
+    expect(first_rule.update(request_attribute: "User-Name")).to be false
+    expect(first_rule.errors.full_messages_for(:request_attribute)).to include("Request attribute has already been added for this policy")
   end
 end


### PR DESCRIPTION
## Context

- Validate uniqueness of rules and responses so there are no duplicate attribute values per policy or MAC authentication bypasses