### PR TITLE
Create default fallback policy when creating a new site

### DIFF
--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -19,6 +19,7 @@ class SitesController < ApplicationController
     authorize! :create, @site
 
     if @site.save
+      @site.policies << Policy.create(name: @site.name, description: "Default fallback policy for #{@site.name}", fallback: true)
       redirect_to site_path(@site), notice: "Successfully created site. #{CONFIG_UPDATE_DELAY_NOTICE}"
     else
       render :new

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -21,7 +21,11 @@
 <h3 class="govuk-heading-m">List of attached policies</h3>
 <p class="govuk-body">
   <span class="govuk-!-font-weight-bold">Fallback policy:</span>
-  <%= @site.fallback_policy.try(:name) || "There are no fallback policies attached to this site." %>
+  <% if @site.fallback_policy %>
+    <%= link_to "#{@site.fallback_policy.try(:name)}", policy_path(@site.fallback_policy), class: "govuk-link" %>
+  <% else %>
+    <%= "There are no fallback policies attached to this site." %>
+  <% end %>
 </p>
 
 <% if @site_policies.any? %>

--- a/spec/acceptance/sites/create_sites_spec.rb
+++ b/spec/acceptance/sites/create_sites_spec.rb
@@ -32,7 +32,7 @@ describe "create sites", type: :feature do
       login_as editor
     end
 
-    it "creates a new site" do
+    it "creates a new site with a fallback policy" do
       visit "/sites"
 
       click_on "Create a new site"
@@ -45,6 +45,13 @@ describe "create sites", type: :feature do
 
       expect(page).to have_content("Successfully created site.")
       expect(page).to have_content("This could take up to 10 minutes to apply.")
+      expect(page).to have_content("My London Site")
+      expect(page).not_to have_content("There are no fallback policies attached to this site.")
+
+      click_on "My London Site"
+
+      expect(current_path).to eql("/policies/#{Policy.last.id}")
+      expect(page).to have_content("Fallback")
       expect(page).to have_content("My London Site")
 
       expect_audit_log_entry_for(editor.email, "create", "Site")


### PR DESCRIPTION
## Context
The fallback policy is created with a site name when creating a site