### PR TITLE
Generate MAB configuration file to support MD5 requests

### DIFF
--- a/app/lib/use_cases/generate_authorised_macs.rb
+++ b/app/lib/use_cases/generate_authorised_macs.rb
@@ -2,8 +2,9 @@ class UseCases::GenerateAuthorisedMacs
   def call(mac_authentication_bypasses:)
     bypasses = mac_authentication_bypasses.map do |bypass|
       responses = bypass.responses.map { |response| [response.response_attribute, response.value].join(" = ") }.join(",\n        ")
+      bypass_address_line = "#{bypass.address} Cleartext-Password := #{bypass.address}"
 
-      bypass.responses.empty? ? bypass.address : [bypass.address, responses].join("\n        ")
+      bypass.responses.empty? ? bypass_address_line : [bypass_address_line, responses].join("\n        ")
     end
 
     "#{bypasses.join("\n\n")}\n"

--- a/spec/use_cases/generate_authorised_macs_spec.rb
+++ b/spec/use_cases/generate_authorised_macs_spec.rb
@@ -16,7 +16,7 @@ describe UseCases::GenerateAuthorisedMacs do
         end
 
         it "generates a authorised_macs configuration file" do
-          expected_config = %(aa-11-22-33-44-55\n\nff-99-88-77-66-55\n)
+          expected_config = %(aa-11-22-33-44-55 Cleartext-Password := aa-11-22-33-44-55\n\nff-99-88-77-66-55 Cleartext-Password := ff-99-88-77-66-55\n)
 
           expect(result).to eq(expected_config)
         end
@@ -35,11 +35,11 @@ describe UseCases::GenerateAuthorisedMacs do
         end
 
         it "generates an authorised_macs configuration file" do
-          expected_config = %(aa-66-77-88-99-00
+          expected_config = %(aa-66-77-88-99-00 Cleartext-Password := aa-66-77-88-99-00
         Tunnel-Medium-Type = IEEE-802,
         Tunnel-Private-Group-Id = 123456
 
-bb-cc-00-11-22-33
+bb-cc-00-11-22-33 Cleartext-Password := bb-cc-00-11-22-33
         Tunnel-Medium-Type = IEEE-802,
         Tunnel-Private-Group-Id = 123456
 )


### PR DESCRIPTION
Given MD5 will be used for MAB, we will use the MAC address as the
username and password for authentication.

Update the authorised macs file to support this.