### PR TITLE
Validation of leading/trailing whitespaces for attribute values

### DIFF
--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -20,5 +20,6 @@ private
 
   def format_response_attribute
     response_attribute.strip! if response_attribute
+    value.strip! if value
   end
 end

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -33,6 +33,7 @@ private
 
   def format_request_attribute
     request_attribute.strip! if request_attribute
+    value.strip! if value
   end
 
   def update_rule_count

--- a/spec/models/mac_authentication_bypass_response_spec.rb
+++ b/spec/models/mac_authentication_bypass_response_spec.rb
@@ -37,6 +37,14 @@ describe MabResponse, type: :model do
     expect(result.response_attribute).to eq("User-Name")
   end
 
+  it "validates the value with leading and trailing whitespace" do
+    result = build(:mab_response, response_attribute: "Tunnel-Type", value: " VLAN ")
+
+    result.valid?
+
+    expect(result.value).to eq("VLAN")
+  end
+
   it "validates an updated response attribute" do
     editable_response = create(:mab_response)
 

--- a/spec/models/policy_response_spec.rb
+++ b/spec/models/policy_response_spec.rb
@@ -37,6 +37,14 @@ describe PolicyResponse, type: :model do
     expect(result.response_attribute).to eq("User-Name")
   end
 
+  it "validates the value with leading and trailing whitespace" do
+    result = build(:policy_response, response_attribute: "Tunnel-Type", value: " VLAN ")
+
+    result.valid?
+
+    expect(result.value).to eq("VLAN")
+  end
+
   it "validates an updated response attribute" do
     editable_response = create(:policy_response)
 

--- a/spec/models/rule_spec.rb
+++ b/spec/models/rule_spec.rb
@@ -37,6 +37,14 @@ describe Rule, type: :model do
     expect(result.request_attribute).to eq("User-Name")
   end
 
+  it "validates the value with leading and trailing whitespace" do
+    result = build(:rule, request_attribute: "Tunnel-Type", value: " VLAN ")
+
+    result.valid?
+
+    expect(result.value).to eq("VLAN")
+  end
+
   it "validates an updated request attribute" do
     editable_rule = create(:rule)
 


### PR DESCRIPTION
## Context

- Update values for rules and responses to strip leading/trailing whitespaces 