### PR TITLE
Show when a policy was attached to a site

### DIFF
--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -33,6 +33,8 @@
     <thead class="govuk-table__head">
       <tr class="govuk-table__row__head">
         <th scope="col" class="govuk-table__header">Policy</th>
+        <th scope="col" class="govuk-table__header">Created</th>
+        <th scope="col" class="govuk-table__header">Updated</th>
         <th scope="col" class="govuk-table__header">
           <%= link_to "Order policies", edit_site_policies_path(@site), class: "govuk-link" %>
         </th>
@@ -42,6 +44,8 @@
       <% @site_policies.each do |sp| %>
         <tr class="govuk-table__row">
           <td class="govuk-table__cell"><%= sp.policy.name %></td>
+          <td class="govuk-table__cell"><%= date_format(sp.created_at) %></td>
+          <td class="govuk-table__cell"><%= date_format(sp.updated_at) %></td>
           <td class="govuk-table__cell"><%= link_to "View", policy_path(sp.policy), class: "govuk-link" %></td>
         </tr>
       <% end %>

--- a/spec/acceptance/sites/order_site_policies_spec.rb
+++ b/spec/acceptance/sites/order_site_policies_spec.rb
@@ -19,11 +19,11 @@ describe "order site policies", type: :feature do
 
   context "when the user is an editor" do
     let(:editor) { create(:user, :editor) }
+    let!(:least_important_site_policy) { create(:site_policy, site_id: site.id, policy_id: least_important_policy.id) }
+    let!(:most_important_site_policy) { create(:site_policy, site_id: site.id, policy_id: most_important_policy.id) }
 
     before do
       login_as editor
-      create(:site_policy, site_id: site.id, policy_id: least_important_policy.id)
-      create(:site_policy, site_id: site.id, policy_id: most_important_policy.id)
     end
 
     it "updates the order of site policies" do
@@ -31,10 +31,14 @@ describe "order site policies", type: :feature do
 
       within "tr.govuk-table__row:nth-child(1)" do
         expect(page).to have_content("Least Important Policy")
+        expect(page).to have_content(date_format(least_important_site_policy.created_at))
+        expect(page).to have_content(date_format(least_important_site_policy.updated_at))
       end
 
       within "tr.govuk-table__row:nth-child(2)" do
         expect(page).to have_content("Most Important Policy")
+        expect(page).to have_content(date_format(most_important_site_policy.created_at))
+        expect(page).to have_content(date_format(most_important_site_policy.updated_at))
       end
 
       click_on "Order policies"


### PR DESCRIPTION
This is different from the policy created / updated dates, it rather
shows when someone made the association.