### PR TITLE
Truncate clients before seeding data

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,7 +6,7 @@ def mac_address
   6.times.map { sprintf("%02x", rand(0..255)) }.join("-")
 end
 
-p "truncating rules, responses, policies, site policies, clients and sites!"
+p "truncating rules, responses, policies, site policies, mab, clients and sites!"
 base_connection = ActiveRecord::Base.connection
 
 base_connection.execute("SET FOREIGN_KEY_CHECKS = 0")
@@ -70,14 +70,14 @@ p "creating MABs"
   )
 end
 
-p "creating certificates"
-100.times do |c|
-  Certificate.create!(
-    name: "Certificate#{c}",
-    description: "Certificate No. #{c}",
-    subject: "Common-Name=Certificate#{c}",
-    expiry_date: Date.today + 1,
-    category: "EAP",
-    filename: "#{c}.pem",
-  )
-end
+# p "creating certificates"
+# 100.times do |c|
+#   Certificate.create!(
+#     name: "Certificate#{c}",
+#     description: "Certificate No. #{c}",
+#     subject: "Common-Name=Certificate#{c}",
+#     expiry_date: Date.today + 1,
+#     category: "EAP",
+#     filename: "#{c}.pem",
+#   )
+# end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,12 +6,12 @@ def mac_address
   6.times.map { sprintf("%02x", rand(0..255)) }.join("-")
 end
 
-p "truncating rules, responses, policies, site policies, and sites!"
+p "truncating rules, responses, policies, site policies, clients and sites!"
 base_connection = ActiveRecord::Base.connection
 
 base_connection.execute("SET FOREIGN_KEY_CHECKS = 0")
 
-%w[rules responses policies site_policies sites mac_authentication_bypasses].each do |table_name|
+%w[rules responses policies site_policies sites clients mac_authentication_bypasses].each do |table_name|
   base_connection.truncate(table_name)
 end
 


### PR DESCRIPTION
### Context
- Dangling clients caused invalid data in the dev environment: Newly created sites had clients attached to them. This is because we wipe sites data but not the client's data.
- Disable seeding certs