### PR TITLE
Handle expired session token gracefully

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,10 @@ class ApplicationController < ActionController::Base
   before_action :authenticate_user!, :set_default_breadcrumbs
   after_action :set_expect_ct_header
 
+  rescue_from ActionController::InvalidAuthenticityToken do
+    redirect_to new_user_session_path
+  end
+
   def new_session_path(_scope)
     new_user_session_path
   end


### PR DESCRIPTION
`ActionController::InvalidAuthenticityToken` is thrown when a user tries to submit information with expired session token:
![image](https://user-images.githubusercontent.com/22743709/141832004-9f5e9d3b-1782-4e1b-92dc-8dfeffa1dddf.png)

This behaviour only occurs on a `:post` request and this is the default and best [forgery protection strategy](https://marcgg.com/blog/2016/08/22/csrf-rails/) against [CSRF](https://owasp.org/www-community/attacks/csrf) in Rails. However, we can catch these errors and redirect.