### PR TITLE
Show associated site count and link to list of sites, on policies page

### DIFF
--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -4,7 +4,11 @@ class SitesController < ApplicationController
   before_action :set_crumbs, only: %i[show new edit destroy policies]
 
   def index
-    @sites = Site.page params[:page]
+    @sites = if params[:policy]
+               Site.page(params[:page]).joins(:policies).where(policies: { id: params[:policy] })
+             else
+               Site.page params[:page]
+             end
   end
 
   def show; end

--- a/app/views/policies/index.html.erb
+++ b/app/views/policies/index.html.erb
@@ -28,7 +28,7 @@
           <td class="govuk-table__cell"><%= policy.fallback ? "Yes" : "No" %></td>
           <td class="govuk-table__cell"><%= date_format(policy.created_at) %></td>
           <td class="govuk-table__cell"><%= date_format(policy.updated_at) %></td>
-          <td class="govuk-table__cell"><%= link_to policy.sites.count, sites_path, class: "govuk-link" %></td>
+          <td class="govuk-table__cell"><%= link_to policy.sites.count, sites_path(:policy => policy.id), class: "govuk-link" %></td>
           <td class="govuk-table__cell">
             <% if can? :manage, Policy %>
               <%= link_to "Manage", policy_path(policy), class: "govuk-link" %>

--- a/app/views/policies/index.html.erb
+++ b/app/views/policies/index.html.erb
@@ -14,6 +14,7 @@
         <th scope="col" class="govuk-table__header">Fallback</th>
         <th scope="col" class="govuk-table__header">Created</th>
         <th scope="col" class="govuk-table__header">Updated</th>
+        <th scope="col" class="govuk-table__header">Sites</th>
         <th scope="col" class="govuk-table__header">
           <span class="govuk-visually-hidden">Actions</span>
         </th>
@@ -27,6 +28,7 @@
           <td class="govuk-table__cell"><%= policy.fallback ? "Yes" : "No" %></td>
           <td class="govuk-table__cell"><%= date_format(policy.created_at) %></td>
           <td class="govuk-table__cell"><%= date_format(policy.updated_at) %></td>
+          <td class="govuk-table__cell"><%= link_to policy.sites.count, sites_path, class: "govuk-link" %></td>
           <td class="govuk-table__cell">
             <% if can? :manage, Policy %>
               <%= link_to "Manage", policy_path(policy), class: "govuk-link" %>

--- a/spec/acceptance/policy/list_policies_spec.rb
+++ b/spec/acceptance/policy/list_policies_spec.rb
@@ -17,4 +17,25 @@ describe "showing a policy", type: :feature do
       expect(page).to have_content date_format(policy.updated_at)
     end
   end
+
+  context "when there are sites associated with the policy" do
+    let!(:policy) { create :policy }
+
+    before do
+      4.times { |i| policy.sites << create(:site, name: "Attached site #{i}") }
+      create(:site, name: "Some other site")
+    end
+
+    it "allows viewing the associated sites" do
+      visit "/policies"
+
+      expect(page).to have_content policy.name
+      expect(page).to have_content "Sites"
+      expect(page).to have_content "4"
+
+      click_on "4"
+
+      expect(current_path).to eq "/sites"
+    end
+  end
 end

--- a/spec/acceptance/policy/list_policies_spec.rb
+++ b/spec/acceptance/policy/list_policies_spec.rb
@@ -36,6 +36,11 @@ describe "showing a policy", type: :feature do
       click_on "4"
 
       expect(current_path).to eq "/sites"
+      expect(page).to have_content "Attached site 0"
+      expect(page).to have_content "Attached site 1"
+      expect(page).to have_content "Attached site 2"
+      expect(page).to have_content "Attached site 3"
+      expect(page).to_not have_content "Some other site"
     end
   end
 end


### PR DESCRIPTION
## Context
As a network engineer, I want to understand the usage of a policy and the ability to spot unused policies, so that I can review the number of sites a policy belongs to.

![image](https://user-images.githubusercontent.com/22743709/141958586-dd985817-8676-4873-b0a3-526d855e2e6c.png)

![image](https://user-images.githubusercontent.com/22743709/141958638-5e66ba5e-47c5-4d17-8c40-1ee2eb35168f.png)

