### PR TITLE
Move fallback policy creation to model

### DIFF
--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -19,7 +19,6 @@ class SitesController < ApplicationController
     authorize! :create, @site
 
     if @site.save
-      @site.policies << Policy.create(name: @site.name, description: "Default fallback policy for #{@site.name}", fallback: true)
       redirect_to site_path(@site), notice: "Successfully created site. #{CONFIG_UPDATE_DELAY_NOTICE}"
     else
       render :new
@@ -106,13 +105,7 @@ private
   end
 
   def policies_params
-    policy_ids = params.require(:policy_ids).reject(&:empty?)
-
-    if params[:fallback_policy_id].present?
-      policy_ids << params.require(:fallback_policy_id)
-    end
-
-    policy_ids
+    (params.require(:policy_ids).reject(&:empty?) << @site.fallback_policy.id).flatten
   end
 
   def site_policies_params

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -3,7 +3,6 @@ class Policy < ApplicationRecord
 
   validates :name, presence: true, uniqueness: { case_sensitive: false }
   validates_presence_of :description
-  validates_inclusion_of :fallback, in: [true, false]
 
   has_many :rules, dependent: :destroy
   has_many :responses, dependent: :destroy

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -8,16 +8,33 @@ class Site < ApplicationRecord
   has_many :policies, through: :site_policy
 
   before_save :generate_tag
+  after_create :create_fallback_policy
+  after_destroy :destroy_fallback_policy
 
   audited
 
   def fallback_policy
-    @fallback_policy ||= policies.where(fallback: true).first
+    policies.where(fallback: true).first
   end
 
 private
 
   def generate_tag
     self.tag = name.parameterize(separator: "_")
+  end
+
+  def create_fallback_policy
+    policies << Policy.create!(
+      name: name,
+      description: "Default fallback policy for #{name}",
+      fallback: true,
+    )
+  end
+
+  def destroy_fallback_policy
+    fallback_policy_id = fallback_policy.id
+
+    site_policy.where(site_id: id, policy_id: fallback_policy_id).destroy_all
+    Policy.find(fallback_policy_id).destroy
   end
 end

--- a/app/views/policies/_form.html.erb
+++ b/app/views/policies/_form.html.erb
@@ -9,15 +9,6 @@
     <%= f.text_area :description, class: "govuk-input" %>
   </div>
 
-  <div class="govuk-form-group">
-    <div class="govuk-checkboxes" data-module="govuk-checkboxes">
-      <div class="govuk-checkboxes__item">
-        <%= f.check_box :fallback, disabled: !f.object.new_record?, class: "govuk-checkboxes__input" %>
-        <%= f.label :fallback, class: "govuk-label govuk-checkboxes__label" %>
-      </div>
-    </div>
-  </div>
-
   <%= f.submit f.object.new_record? ? "Create" : "Update", {
     class: "govuk-button",
     "data-module" => "govuk-button"

--- a/app/views/policies/index.html.erb
+++ b/app/views/policies/index.html.erb
@@ -30,7 +30,9 @@
           <td class="govuk-table__cell">
             <% if can? :manage, Policy %>
               <%= link_to "Manage", policy_path(policy), class: "govuk-link" %>
-              <%= link_to "Delete", policy_path(policy), class:"govuk-link", method: :delete %>
+              <% unless policy.fallback? %>
+                <%= link_to "Delete", policy_path(policy), class:"govuk-link", method: :delete %>
+              <% end%>
             <% else %>
               <%= link_to "View", policy_path(policy), class: "govuk-link" %>
             <% end %>

--- a/db/migrate/20211116101726_default_fallback_false_policies.rb
+++ b/db/migrate/20211116101726_default_fallback_false_policies.rb
@@ -1,0 +1,7 @@
+class DefaultFallbackFalsePolicies < ActiveRecord::Migration[6.1]
+  def change
+    change_table :policies do |t|
+      t.change :fallback, :boolean, default: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_15_153737) do
+ActiveRecord::Schema.define(version: 2021_11_16_101726) do
 
   create_table "audits", charset: "utf8", force: :cascade do |t|
     t.integer "auditable_id"
@@ -68,7 +68,7 @@ ActiveRecord::Schema.define(version: 2021_11_15_153737) do
     t.text "description", null: false
     t.datetime "created_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.datetime "updated_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
-    t.boolean "fallback", null: false
+    t.boolean "fallback", default: false, null: false
     t.integer "rule_count", default: 0
   end
 

--- a/spec/acceptance/policy/create_policies_spec.rb
+++ b/spec/acceptance/policy/create_policies_spec.rb
@@ -50,26 +50,6 @@ describe "create policies", type: :feature do
       expect_audit_log_entry_for(editor.email, "create", "Policy")
     end
 
-    it "creates a new fallback policy" do
-      visit "/policies"
-
-      click_on "Create a new policy"
-
-      expect(current_path).to eql("/policies/new")
-
-      fill_in "Name", with: "My Fallback Policy"
-      fill_in "Description", with: "This is a fallback policy"
-      check("Fallback", allow_label_click: true)
-
-      click_on "Create"
-
-      expect(page).to have_content("Successfully created policy.")
-      expect(page).to have_content("My Fallback Policy")
-      expect(page).to have_content("Fallback")
-
-      expect_audit_log_entry_for(editor.email, "create", "Policy")
-    end
-
     it "displays error if form cannot be submitted" do
       visit "/policies/new"
 

--- a/spec/acceptance/policy/delete_policies_spec.rb
+++ b/spec/acceptance/policy/delete_policies_spec.rb
@@ -24,7 +24,7 @@ describe "delete policies", type: :feature do
     it "delete a policy" do
       visit "/policies"
 
-      click_on "Delete"
+      find_link("Delete", href: "/policies/#{policy.id}").click
 
       expect(page).to have_content("Are you sure you want to delete this policy?")
       expect(page).to have_content(policy.name)
@@ -46,7 +46,7 @@ describe "delete policies", type: :feature do
       it "can delete the policy and the rules" do
         visit "/policies"
 
-        click_on "Delete"
+        find_link("Delete", href: "/policies/#{policy.id}").click
         click_on "Delete policy"
 
         expect(page).to have_content("Successfully deleted policy.")
@@ -57,20 +57,18 @@ describe "delete policies", type: :feature do
     end
 
     context "when a policy is attached to a site" do
-      before do
-        create(:site, policies: [policy])
-      end
+      let!(:site) { create(:site, policies: [policy]) }
 
       it "can delete the attached policy" do
         visit "/sites"
 
-        click_on "Manage"
+        find_link("Manage", href: "/sites/#{site.id}").click
 
         expect(page).to have_content(policy.name)
 
         visit "/policies"
 
-        click_on "Delete"
+        find_link("Delete", href: "/policies/#{policy.id}").click
         click_on "Delete policy"
 
         expect(page).to have_content("Successfully deleted policy.")
@@ -78,7 +76,7 @@ describe "delete policies", type: :feature do
 
         visit "/sites"
 
-        click_on "Manage"
+        find_link("Manage", href: "/sites/#{site.id}").click
 
         expect(page).not_to have_content(policy.name)
       end

--- a/spec/acceptance/policy/update_policies_spec.rb
+++ b/spec/acceptance/policy/update_policies_spec.rb
@@ -42,8 +42,6 @@ describe "update policies", type: :feature do
 
       expect(page).to have_field("Name", with: policy.name)
 
-      expect(page).to have_field("policy_fallback", type: "checkbox", disabled: true)
-
       fill_in "Name", with: "My London Policy"
 
       click_on "Update"

--- a/spec/acceptance/policy/view_policies_spec.rb
+++ b/spec/acceptance/policy/view_policies_spec.rb
@@ -20,7 +20,7 @@ describe "showing a policy", type: :feature do
       it "allows viewing policies" do
         visit "/policies"
 
-        click_on "View", match: :first
+        find_link("View", href: "/policies/#{policy.id}").click
 
         expect(page).to have_content policy.name
         expect(page).to have_content policy.description

--- a/spec/acceptance/sites/attach_policies_spec.rb
+++ b/spec/acceptance/sites/attach_policies_spec.rb
@@ -34,11 +34,8 @@ describe "attach policies to a site", type: :feature do
       it "does allow attaching policies to a site" do
         visit "/sites"
 
-        click_on "Manage", match: :first
-
-        click_on "Manage policies"
-
-        expect(current_path).to eq("/sites/#{site.id}/policies")
+        find_link("Manage", href: "/sites/#{site.id}").click
+        find_link("Manage policies", href: "/sites/#{site.id}/policies?site_id=#{site.id}").click
 
         check "First Policy", allow_label_click: true
         check "Second Policy", allow_label_click: true
@@ -79,6 +76,17 @@ describe "attach policies to a site", type: :feature do
           click_on "Update"
 
           expect(page).to_not have_content("First Policy")
+        end
+
+        it "keeps the fallback policy for the site when attaching new policies" do
+          visit "/sites/#{site.id}"
+
+          click_on "Manage policies"
+          check "First Policy"
+          click_on "Update"
+
+          expect(page).to have_content("First Policy")
+          expect(page).to have_content("Fallback policy: #{site.name}")
         end
       end
     end

--- a/spec/acceptance/sites/delete_sites_spec.rb
+++ b/spec/acceptance/sites/delete_sites_spec.rb
@@ -24,7 +24,7 @@ describe "delete sites", type: :feature do
     it "delete a site" do
       visit "/sites"
 
-      click_on "Delete"
+      find_link("Delete", href: "/sites/#{site.id}").click
 
       expect(page).to have_content("Are you sure you want to delete this site?")
       expect(page).to have_content(site.name)

--- a/spec/acceptance/sites/show_site_spec.rb
+++ b/spec/acceptance/sites/show_site_spec.rb
@@ -20,7 +20,7 @@ describe "showing a site", type: :feature do
       it "allows viewing sites" do
         visit "/sites"
 
-        click_on "View", match: :first
+        find_link("View", href: "/sites/#{site.id}").click
 
         expect(page).to have_content site.name
         expect(page).to have_content "your_brilliant_site"

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -16,4 +16,18 @@ RSpec.describe Site, type: :model do
   it "responds to #fallback_policy" do
     expect(subject.fallback_policy).to be_nil
   end
+
+  it "deletes a fallback policy when a site is deleted" do
+    site = create(:site)
+    fallback_policy_id = site.fallback_policy.id
+
+    expect(site.fallback_policy).to_not be_nil
+    expect(site.site_policy.where(site_id: site.id, policy_id: fallback_policy_id)).to_not be_nil
+
+    site.destroy!
+
+    expect(Policy.find_by(id: fallback_policy_id)).to be_nil
+    expect(site.fallback_policy).to be_nil
+    expect(site.site_policy.where(site_id: site.id, policy_id: fallback_policy_id).first).to be_nil
+  end
 end


### PR DESCRIPTION
Ensure fallback policy is deleted when site is deleted

Update specs to find correct links as this causes more than one policy
to exist.