### PR TITLE
Show number of associated sites when deleting policies

### DIFF
--- a/app/views/policies/destroy.html.erb
+++ b/app/views/policies/destroy.html.erb
@@ -1,8 +1,12 @@
 <h2 class="govuk-heading-l">Are you sure you want to delete this policy?</h2>
 
 <div class="govuk-inset-text">
-  <h4 class="govuk-heading-s">Policy name:</h4>
-  <p class="govuk-body"><%= @policy.name %></p>
+  <p class="govuk-body">
+    <span class="govuk-!-font-weight-bold">Policy name:</span> <%= @policy.name %>
+  </p>
+  <p class="govuk-body">
+    This policy is attached to <%= link_to @policy.sites.count, sites_path(:policy => @policy.id), class: "govuk-link govuk-!-font-weight-bold" %> site(s).
+  </p>
 </div>
 
 <%=

--- a/spec/acceptance/policy/delete_policies_spec.rb
+++ b/spec/acceptance/policy/delete_policies_spec.rb
@@ -58,6 +58,7 @@ describe "delete policies", type: :feature do
 
     context "when a policy is attached to a site" do
       let!(:site) { create(:site, policies: [policy]) }
+      let!(:another_site) { create(:site, policies: [policy]) }
 
       it "can delete the attached policy" do
         visit "/sites"
@@ -79,6 +80,20 @@ describe "delete policies", type: :feature do
         find_link("Manage", href: "/sites/#{site.id}").click
 
         expect(page).not_to have_content(policy.name)
+      end
+
+      it "shows the number of associated sites when deleting the policy" do
+        visit "/sites"
+
+        find_link("Manage", href: "/sites/#{site.id}").click
+
+        expect(page).to have_content(policy.name)
+
+        visit "/policies"
+
+        find_link("Delete", href: "/policies/#{policy.id}").click
+
+        expect(page).to have_content("This policy is attached to 2 site(s).")
       end
     end
   end


### PR DESCRIPTION
## Context

- show the number of associated sites when deleting a policy
- link to filtered sites page that displays all the sites with the policy attached

<img width="718" alt="image" src="https://user-images.githubusercontent.com/47318342/142203886-bfbbb17f-7371-4ca7-9ff2-0927d7692ba8.png">
