### PR TITLE
Update certificate page to show category column

### DIFF
--- a/app/views/certificates/index.html.erb
+++ b/app/views/certificates/index.html.erb
@@ -12,7 +12,7 @@
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th scope="col" class="govuk-table__header">Name</th>
-        <th scope="col" class="govuk-table__header">File Name</th>
+        <th scope="col" class="govuk-table__header">Category</th>
         <th scope="col" class="govuk-table__header">Expiry Date</th>
         <th scope="col" class="govuk-table__header">Created</th>
         <th scope="col" class="govuk-table__header">
@@ -24,7 +24,7 @@
       <% @certificates.each do |certificate| %>
         <tr class="govuk-table__row">
           <td class="govuk-table__cell"><%= certificate.name %></td>
-          <td class="govuk-table__cell"><%= certificate.filename %></td>
+          <td class="govuk-table__cell"><%= certificate.category %></td>
           <td class="govuk-table__cell"><%= certificate.expiry_date %></td>
           <td class="govuk-table__cell"><%= date_format(certificate.created_at) %></td>
           <td class="govuk-table__cell">

--- a/spec/acceptance/certificate/list_certificates_spec.rb
+++ b/spec/acceptance/certificate/list_certificates_spec.rb
@@ -13,7 +13,7 @@ describe "showing a certificate", type: :feature do
 
       expect(page).to have_content certificate.name
       expect(page).to have_content certificate.expiry_date
-      expect(page).to have_content certificate.filename
+      expect(page).to have_content certificate.category
       expect(page).to have_content date_format(certificate.created_at)
     end
   end

--- a/spec/acceptance/certificate/view_certificate_spec.rb
+++ b/spec/acceptance/certificate/view_certificate_spec.rb
@@ -21,8 +21,8 @@ describe "showing a certificate", type: :feature do
         visit "/certificates"
 
         expect(page).to have_content certificate.name
+        expect(page).to have_content certificate.category
         expect(page).to have_content certificate.expiry_date
-        expect(page).to have_content certificate.filename
       end
     end
   end


### PR DESCRIPTION
## Context

- category column replaces the file name column on the list of certificates page

<img width="982" alt="image" src="https://user-images.githubusercontent.com/47318342/142206691-e71a6469-3a37-4357-8b84-0f545a6f19ba.png">
