### PR TITLE
Delete button on show pages

### DIFF
--- a/app/views/certificates/index.html.erb
+++ b/app/views/certificates/index.html.erb
@@ -30,7 +30,6 @@
           <td class="govuk-table__cell">
             <% if can? :manage, Certificate %>
               <%= link_to "View", certificate_path(certificate), class:"govuk-link" %>
-              <%= link_to "Delete", certificate_path(certificate), class:"govuk-link", method: :delete %>
             <% end %>
           </td>
         </tr>

--- a/app/views/certificates/show.html.erb
+++ b/app/views/certificates/show.html.erb
@@ -44,3 +44,7 @@
     <dd class="govuk-summary-list__value"><%= @certificate.filename %></dd>
   </div>
 </dl>
+
+<% if can? :manage, Certificate %>
+  <%= link_to "Delete", certificate_path(@certificate), class:"govuk-button", method: :delete %>
+<% end %>

--- a/app/views/certificates/show.html.erb
+++ b/app/views/certificates/show.html.erb
@@ -46,5 +46,5 @@
 </dl>
 
 <% if can? :manage, Certificate %>
-  <%= link_to "Delete", certificate_path(@certificate), class:"govuk-button", method: :delete %>
+  <%= link_to "Delete", certificate_path(@certificate), class:"govuk-button govuk-button--warning", method: :delete %>
 <% end %>

--- a/app/views/mac_authentication_bypasses/index.html.erb
+++ b/app/views/mac_authentication_bypasses/index.html.erb
@@ -30,7 +30,6 @@
           <td class="govuk-table__cell">
             <% if can? :manage, MacAuthenticationBypass %>
               <%= link_to "Manage", mac_authentication_bypass_path(bypass), class:"govuk-link" %>
-              <%= link_to "Delete", mac_authentication_bypass_path(bypass), class:"govuk-link", method: :delete %>
             <% end %>
           </td>
         </tr>

--- a/app/views/mac_authentication_bypasses/show.html.erb
+++ b/app/views/mac_authentication_bypasses/show.html.erb
@@ -51,3 +51,7 @@
     </tbody>
   </table>
 <% end %>
+
+<% if can? :manage, MacAuthenticationBypass %>
+  <%= link_to "Delete", mac_authentication_bypass_path(@mac_authentication_bypass), class:"govuk-button", method: :delete %>
+<% end %>

--- a/app/views/mac_authentication_bypasses/show.html.erb
+++ b/app/views/mac_authentication_bypasses/show.html.erb
@@ -53,5 +53,5 @@
 <% end %>
 
 <% if can? :manage, MacAuthenticationBypass %>
-  <%= link_to "Delete", mac_authentication_bypass_path(@mac_authentication_bypass), class:"govuk-button", method: :delete %>
+  <%= link_to "Delete", mac_authentication_bypass_path(@mac_authentication_bypass), class:"govuk-button govuk-button--warning", method: :delete %>
 <% end %>

--- a/app/views/policies/index.html.erb
+++ b/app/views/policies/index.html.erb
@@ -32,9 +32,6 @@
           <td class="govuk-table__cell">
             <% if can? :manage, Policy %>
               <%= link_to "Manage", policy_path(policy), class: "govuk-link" %>
-              <% unless policy.fallback? %>
-                <%= link_to "Delete", policy_path(policy), class:"govuk-link", method: :delete %>
-              <% end%>
             <% else %>
               <%= link_to "View", policy_path(policy), class: "govuk-link" %>
             <% end %>

--- a/app/views/policies/show.html.erb
+++ b/app/views/policies/show.html.erb
@@ -88,3 +88,9 @@
     </tbody>
   </table>
 <% end %>
+
+<% if can? :manage, Policy %>
+  <% unless @policy.fallback? %>
+    <%= link_to "Delete", policy_path(@policy), class:"govuk-button", method: :delete %>
+  <% end%>
+<% end%>

--- a/app/views/policies/show.html.erb
+++ b/app/views/policies/show.html.erb
@@ -91,6 +91,6 @@
 
 <% if can? :manage, Policy %>
   <% unless @policy.fallback? %>
-    <%= link_to "Delete", policy_path(@policy), class:"govuk-button", method: :delete %>
+    <%= link_to "Delete", policy_path(@policy), class:"govuk-button govuk-button--warning", method: :delete %>
   <% end%>
 <% end%>

--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -26,7 +26,6 @@
           <td class="govuk-table__cell">
             <% if can? :manage, Site %>
               <%= link_to "Manage", site_path(site), class: "govuk-link" %>
-              <%= link_to "Delete", site_path(site), class:"govuk-link", method: :delete %>
             <% else %>
               <%= link_to "View", site_path(site), class: "govuk-link" %>
             <% end %>

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -87,3 +87,7 @@
     </tbody>
   </table>
 <% end %>
+
+<% if can? :manage, Site %>
+  <%= link_to "Delete", site_path(@site), class:"govuk-button", method: :delete %>
+<% end %>

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -89,5 +89,5 @@
 <% end %>
 
 <% if can? :manage, Site %>
-  <%= link_to "Delete", site_path(@site), class:"govuk-button", method: :delete %>
+  <%= link_to "Delete", site_path(@site), class:"govuk-button govuk-button--warning", method: :delete %>
 <% end %>

--- a/spec/acceptance/certificate/delete_certificate_spec.rb
+++ b/spec/acceptance/certificate/delete_certificate_spec.rb
@@ -1,23 +1,23 @@
 require "rails_helper"
 
 describe "delete certificates", type: :feature do
+  let!(:certificate) do
+    create(:certificate)
+  end
+
   context "when the user is a viewer" do
     before do
       login_as create(:user, :reader)
     end
 
     it "does not allow deleting certificates" do
-      visit "/certificates"
+      visit "/certificates/#{certificate.id}"
 
       expect(page).not_to have_content "Delete"
     end
   end
 
   context "when the user is an editor" do
-    let!(:certificate) do
-      create(:certificate)
-    end
-
     let(:editor) { create(:user, :editor) }
 
     before do
@@ -25,7 +25,7 @@ describe "delete certificates", type: :feature do
     end
 
     it "does delete a certificate" do
-      visit "/certificates"
+      visit "/certificates/#{certificate.id}"
 
       click_on "Delete"
 

--- a/spec/acceptance/clients/delete_clients_spec.rb
+++ b/spec/acceptance/clients/delete_clients_spec.rb
@@ -46,7 +46,7 @@ describe "delete clients", type: :feature do
 
         visit "/sites/#{site.id}"
 
-        click_on "Delete"
+        find_link("Delete", href: "/sites/#{site.id}/clients/#{client.id}").click
 
         expect(page).to have_content("Are you sure you want to delete this client?")
         expect(page).to have_content(client.ip_range)

--- a/spec/acceptance/mac_authentication_bypass/delete_spec.rb
+++ b/spec/acceptance/mac_authentication_bypass/delete_spec.rb
@@ -1,23 +1,23 @@
 require "rails_helper"
 
 describe "delete MAC authentication bypasses", type: :feature do
+  let!(:mac_authentication_bypass) do
+    create(:mac_authentication_bypass)
+  end
+
   context "when the user is a viewer" do
     before do
       login_as create(:user, :reader)
     end
 
     it "does not allow deleting bypasses" do
-      visit "/mac_authentication_bypasses"
+      visit "/mac_authentication_bypasses/#{mac_authentication_bypass.id}"
 
       expect(page).not_to have_content "Delete"
     end
   end
 
   context "when the user is an editor" do
-    let!(:mac_authentication_bypass) do
-      create(:mac_authentication_bypass)
-    end
-
     let(:editor) { create(:user, :editor) }
 
     before do
@@ -27,7 +27,7 @@ describe "delete MAC authentication bypasses", type: :feature do
     it "does delete a MAC address" do
       expect_service_deployment
 
-      visit "/mac_authentication_bypasses"
+      visit "/mac_authentication_bypasses/#{mac_authentication_bypass.id}"
 
       click_on "Delete"
 

--- a/spec/acceptance/policy/delete_policies_spec.rb
+++ b/spec/acceptance/policy/delete_policies_spec.rb
@@ -22,7 +22,7 @@ describe "delete policies", type: :feature do
     end
 
     it "delete a policy" do
-      visit "/policies"
+      visit "/policies/#{policy.id}"
 
       find_link("Delete", href: "/policies/#{policy.id}").click
 
@@ -44,7 +44,7 @@ describe "delete policies", type: :feature do
       end
 
       it "can delete the policy and the rules" do
-        visit "/policies"
+        visit "/policies/#{policy.id}"
 
         find_link("Delete", href: "/policies/#{policy.id}").click
         click_on "Delete policy"
@@ -67,7 +67,7 @@ describe "delete policies", type: :feature do
 
         expect(page).to have_content(policy.name)
 
-        visit "/policies"
+        visit "/policies/#{policy.id}"
 
         find_link("Delete", href: "/policies/#{policy.id}").click
         click_on "Delete policy"
@@ -89,7 +89,7 @@ describe "delete policies", type: :feature do
 
         expect(page).to have_content(policy.name)
 
-        visit "/policies"
+        visit "/policies/#{policy.id}"
 
         find_link("Delete", href: "/policies/#{policy.id}").click
 

--- a/spec/acceptance/policy/delete_policies_spec.rb
+++ b/spec/acceptance/policy/delete_policies_spec.rb
@@ -1,20 +1,21 @@
 require "rails_helper"
 
 describe "delete policies", type: :feature do
+  let!(:policy) { create(:policy) }
+
   context "when the user is a viewer" do
     before do
       login_as create(:user, :reader)
     end
 
     it "does not allow deleting policies" do
-      visit "/policies"
+      visit "/policies/#{policy.id}"
 
       expect(page).not_to have_content "Delete"
     end
   end
 
   context "when the user is an editor" do
-    let!(:policy) { create(:policy) }
     let(:editor) { create(:user, :editor) }
 
     before do

--- a/spec/acceptance/policy/rules/delete_rules_spec.rb
+++ b/spec/acceptance/policy/rules/delete_rules_spec.rb
@@ -30,7 +30,7 @@ describe "delete rules", type: :feature do
       it "delete an existing rule" do
         visit "/policies/#{policy.id}"
 
-        click_on "Delete"
+        find_link("Delete", href: "/policies/#{policy.id}/rules/#{rule.id}").click
 
         expect(page).to have_content("Are you sure you want to delete this rule?")
         expect(page).to have_content(rule.request_attribute)

--- a/spec/acceptance/sites/delete_sites_spec.rb
+++ b/spec/acceptance/sites/delete_sites_spec.rb
@@ -1,20 +1,21 @@
 require "rails_helper"
 
 describe "delete sites", type: :feature do
+  let!(:site) { create(:site) }
+
   context "when the user is a viewer" do
     before do
       login_as create(:user, :reader)
     end
 
     it "does not allow deleting sites" do
-      visit "/sites"
+      visit "/sites/#{site.id}"
 
       expect(page).not_to have_content "Delete"
     end
   end
 
   context "when the user is an editor" do
-    let!(:site) { create(:site) }
     let(:editor) { create(:user, :editor) }
 
     before do
@@ -22,7 +23,7 @@ describe "delete sites", type: :feature do
     end
 
     it "delete a site" do
-      visit "/sites"
+      visit "/sites/#{site.id}"
 
       find_link("Delete", href: "/sites/#{site.id}").click
 

--- a/spec/support/shared_examples/responses/delete_responses.rb
+++ b/spec/support/shared_examples/responses/delete_responses.rb
@@ -29,7 +29,7 @@ RSpec.shared_examples "response deletion" do |domain, response|
       it "delete an existing response" do
         visit "/#{domain.to_s.pluralize}/#{created_domain.id}"
 
-        click_on "Delete"
+        find_link("Delete", href: "/#{domain.to_s.pluralize}/#{created_domain.id}/#{response.to_s.pluralize}/#{created_response.id}").click
 
         expect(page).to have_content("Are you sure you want to delete this response?")
         expect(page).to have_content("Response attribute: #{created_response.response_attribute}")


### PR DESCRIPTION
## Context

- delete button removed from index pages for sites, policies, MABs, and certificates
- delete button now shown on the show page for each of the above

![image](https://user-images.githubusercontent.com/47318342/142221211-800148d5-33ef-4d78-951f-4957bb9f24b6.png)
