### PR TITLE
Display additional certificate details

### DIFF
--- a/app/controllers/certificates_controller.rb
+++ b/app/controllers/certificates_controller.rb
@@ -18,6 +18,8 @@ class CertificatesController < ApplicationController
       certificate_metadata = UseCases::ReadCertificateMetadata.new(certificate: uploaded_certificate_file.read).call
       @certificate.expiry_date = certificate_metadata[:expiry_date]
       @certificate.subject = certificate_metadata[:subject]
+      @certificate.issuer = certificate_metadata[:issuer]
+      @certificate.serial = certificate_metadata[:serial]
       @certificate.filename = server_certificate? ? "server.pem" : uploaded_certificate_file.original_filename
     end
 

--- a/app/lib/use_cases/read_certificate_metadata.rb
+++ b/app/lib/use_cases/read_certificate_metadata.rb
@@ -12,6 +12,7 @@ module UseCases
         expiry_date: decoded_certificate.not_after.to_date,
         subject: decoded_certificate.subject.to_s,
         issuer: decoded_certificate.issuer.to_s,
+        serial: decoded_certificate.serial.to_s
       }
     rescue StandardError
       {}

--- a/app/lib/use_cases/read_certificate_metadata.rb
+++ b/app/lib/use_cases/read_certificate_metadata.rb
@@ -11,6 +11,7 @@ module UseCases
       {
         expiry_date: decoded_certificate.not_after.to_date,
         subject: decoded_certificate.subject.to_s,
+        issuer: decoded_certificate.issuer.to_s,
       }
     rescue StandardError
       {}

--- a/app/lib/use_cases/read_certificate_metadata.rb
+++ b/app/lib/use_cases/read_certificate_metadata.rb
@@ -8,6 +8,7 @@ module UseCases
 
     def call
       decoded_certificate = OpenSSL::X509::Certificate.new(certificate)
+
       {
         expiry_date: decoded_certificate.not_after.to_date,
         subject: decoded_certificate.subject.to_s,

--- a/app/lib/use_cases/read_certificate_metadata.rb
+++ b/app/lib/use_cases/read_certificate_metadata.rb
@@ -13,7 +13,7 @@ module UseCases
         expiry_date: decoded_certificate.not_after.to_date,
         subject: decoded_certificate.subject.to_s,
         issuer: decoded_certificate.issuer.to_s,
-        serial: decoded_certificate.serial.to_s
+        serial: decoded_certificate.serial.to_s,
       }
     rescue StandardError
       {}

--- a/app/views/certificates/show.html.erb
+++ b/app/views/certificates/show.html.erb
@@ -26,17 +26,35 @@
 
 <dl class="govuk-summary-list">
   <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">Subject</dt>
-    <dd class="govuk-summary-list__value"><%= @certificate.subject %></dd>
+    <dt class="govuk-summary-list__key">Expiry Date</dt>
+    <dd class="govuk-summary-list__value"><%= @certificate.expiry_date %></dd>
   </div>
 </dl>
 
 <dl class="govuk-summary-list">
   <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">Expiry Date</dt>
-    <dd class="govuk-summary-list__value"><%= @certificate.expiry_date %></dd>
+    <dt class="govuk-summary-list__key">Subject</dt>
+    <dd class="govuk-summary-list__value"><%= @certificate.subject %></dd>
   </div>
 </dl>
+
+<% unless @certificate.issuer.nil? %>
+  <dl class="govuk-summary-list">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">Issuer</dt>
+      <dd class="govuk-summary-list__value"><%= @certificate.issuer %></dd>
+    </div>
+  </dl>
+<% end %>
+
+<% unless @certificate.serial.nil? %>
+  <dl class="govuk-summary-list">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">Serial</dt>
+      <dd class="govuk-summary-list__value"><%= @certificate.serial %></dd>
+    </div>
+  </dl>
+<% end %>
 
 <dl class="govuk-summary-list">
   <div class="govuk-summary-list__row">

--- a/db/migrate/20211117153312_add_certificate_details_to_certificates.rb
+++ b/db/migrate/20211117153312_add_certificate_details_to_certificates.rb
@@ -1,0 +1,6 @@
+class AddCertificateDetailsToCertificates < ActiveRecord::Migration[6.1]
+  def change
+    add_column :certificates, :issuer, :text
+    add_column :certificates, :serial, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_16_101726) do
+ActiveRecord::Schema.define(version: 2021_11_17_153312) do
 
   create_table "audits", charset: "utf8", force: :cascade do |t|
     t.integer "auditable_id"
@@ -43,6 +43,8 @@ ActiveRecord::Schema.define(version: 2021_11_16_101726) do
     t.datetime "updated_at", precision: 6, null: false
     t.text "filename", null: false
     t.string "category", null: false
+    t.text "issuer"
+    t.text "serial"
   end
 
   create_table "clients", charset: "utf8", force: :cascade do |t|

--- a/spec/acceptance/certificate/view_certificate_spec.rb
+++ b/spec/acceptance/certificate/view_certificate_spec.rb
@@ -24,6 +24,17 @@ describe "showing a certificate", type: :feature do
         expect(page).to have_content certificate.category
         expect(page).to have_content certificate.expiry_date
       end
+
+      it "allows viewing the details of a certificate" do
+        visit "/certificates/#{certificate.id}"
+
+        expect(page).to have_content certificate.name
+        expect(page).to have_content certificate.category
+        expect(page).to have_content certificate.expiry_date
+        expect(page).to have_content certificate.subject
+        expect(page).to have_content certificate.issuer
+        expect(page).to have_content certificate.serial
+      end
     end
   end
 end

--- a/spec/factories/certificate.rb
+++ b/spec/factories/certificate.rb
@@ -4,6 +4,8 @@ FactoryBot.define do
     sequence(:description) { |n| "Certificate description #{n}" }
     sequence(:expiry_date) { Date.today }
     sequence(:subject) { |n| "Certificate subject #{n}" }
+    sequence(:issuer) { |n| "Certificate issuer #{n}" }
+    sequence(:serial) { |n| "Certificate serial #{n}" }
     sequence(:filename) { |n| "ca#{n}.pem" }
     category { "EAP" }
   end

--- a/spec/use_cases/read_certificate_metadata_spec.rb
+++ b/spec/use_cases/read_certificate_metadata_spec.rb
@@ -21,6 +21,12 @@ describe UseCases::ReadCertificateMetadata do
       expected_subject = "/C=GB/ST=London/L=London/O=MoJ/OU=MoJ/CN=MoJTestCert/emailAddress=testcert@moj.gov.uk"
       expect(subject).to eq expected_subject
     end
+
+    it "extracts the issuer of the certificate" do
+      issuer = use_case.call[:issuer]
+      expected_issuer = "/C=GB/ST=London/L=London/O=MoJ/OU=MoJ/CN=MoJTestCert/emailAddress=testcert@moj.gov.uk"
+      expect(issuer).to eq expected_issuer
+    end
   end
 
   context "when the certificate is invalid" do

--- a/spec/use_cases/read_certificate_metadata_spec.rb
+++ b/spec/use_cases/read_certificate_metadata_spec.rb
@@ -27,6 +27,12 @@ describe UseCases::ReadCertificateMetadata do
       expected_issuer = "/C=GB/ST=London/L=London/O=MoJ/OU=MoJ/CN=MoJTestCert/emailAddress=testcert@moj.gov.uk"
       expect(issuer).to eq expected_issuer
     end
+
+    it "extracts the serial of the certificate" do
+      serial = use_case.call[:serial]
+      expected_serial = "261449075976929706890225671845538541127278523818"
+      expect(serial).to eq expected_serial
+    end
   end
 
   context "when the certificate is invalid" do


### PR DESCRIPTION
## Context

- Extract and display `issuer` and `serial` from `*.pem` certificate files on certificate view page
- Add DB migration to store issuer and serial values in the database

Reference to source: https://docs.ruby-lang.org/en/2.4.0/OpenSSL/X509/Certificate.html

<img width="995" alt="image" src="https://user-images.githubusercontent.com/47318342/142234976-c4067720-b15c-4ff2-b40d-6140d5279053.png">
