### PR TITLE
Display extensions on certificates

### DIFF
--- a/app/controllers/certificates_controller.rb
+++ b/app/controllers/certificates_controller.rb
@@ -20,6 +20,7 @@ class CertificatesController < ApplicationController
       @certificate.subject = certificate_metadata[:subject]
       @certificate.issuer = certificate_metadata[:issuer]
       @certificate.serial = certificate_metadata[:serial]
+      @certificate.extensions = certificate_metadata[:extensions]
       @certificate.filename = server_certificate? ? "server.pem" : uploaded_certificate_file.original_filename
     end
 

--- a/app/lib/use_cases/read_certificate_metadata.rb
+++ b/app/lib/use_cases/read_certificate_metadata.rb
@@ -10,7 +10,7 @@ module UseCases
       decoded_certificate = OpenSSL::X509::Certificate.new(certificate)
 
       extensions = decoded_certificate.extensions.map do |extension|
-        "#{extension.oid}:#{" critical" if extension.critical?}\n\t#{extension.value}"
+        "#{extension.oid}:#{' critical' if extension.critical?}\n\t#{extension.value}"
       end
 
       {
@@ -18,7 +18,7 @@ module UseCases
         subject: decoded_certificate.subject.to_s,
         issuer: decoded_certificate.issuer.to_s,
         serial: decoded_certificate.serial.to_s,
-        extensions: extensions.join("\n\n")
+        extensions: extensions.join("\n\n"),
       }
     rescue StandardError
       {}

--- a/app/lib/use_cases/read_certificate_metadata.rb
+++ b/app/lib/use_cases/read_certificate_metadata.rb
@@ -9,11 +9,16 @@ module UseCases
     def call
       decoded_certificate = OpenSSL::X509::Certificate.new(certificate)
 
+      extensions = decoded_certificate.extensions.map do |extension|
+        "#{extension.oid}:#{" critical" if extension.critical?}\n\t#{extension.value}"
+      end
+
       {
         expiry_date: decoded_certificate.not_after.to_date,
         subject: decoded_certificate.subject.to_s,
         issuer: decoded_certificate.issuer.to_s,
         serial: decoded_certificate.serial.to_s,
+        extensions: extensions.join("\n\n")
       }
     rescue StandardError
       {}

--- a/app/views/certificates/show.html.erb
+++ b/app/views/certificates/show.html.erb
@@ -56,6 +56,15 @@
   </dl>
 <% end %>
 
+<% unless @certificate.extensions.nil? %>
+  <dl class="govuk-summary-list">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">Extensions</dt>
+      <dd class="govuk-summary-list__value"><pre><code><%= @certificate.extensions %></code></pre></dd>
+    </div>
+  </dl>
+<% end %>
+
 <dl class="govuk-summary-list">
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">Certificate File</dt>

--- a/app/views/certificates/show.html.erb
+++ b/app/views/certificates/show.html.erb
@@ -60,7 +60,7 @@
   <dl class="govuk-summary-list">
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">Extensions</dt>
-      <dd class="govuk-summary-list__value"><%= sanitize @certificate.extensions.gsub("\n", "<br />") %></dd>
+      <dd class="govuk-summary-list__value"><%= sanitize @certificate.extensions.gsub("\n\n\n", "\n\n").gsub("\n", "<br />") %></dd>
     </div>
   </dl>
 <% end %>

--- a/app/views/certificates/show.html.erb
+++ b/app/views/certificates/show.html.erb
@@ -60,7 +60,7 @@
   <dl class="govuk-summary-list">
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">Extensions</dt>
-      <dd class="govuk-summary-list__value"><pre><code><%= @certificate.extensions %></code></pre></dd>
+      <dd class="govuk-summary-list__value"><%= sanitize @certificate.extensions.gsub("\n", "<br />") %></dd>
     </div>
   </dl>
 <% end %>

--- a/db/migrate/20211118140430_add_extensions_column_to_certificates.rb
+++ b/db/migrate/20211118140430_add_extensions_column_to_certificates.rb
@@ -1,0 +1,5 @@
+class AddExtensionsColumnToCertificates < ActiveRecord::Migration[6.1]
+  def change
+    add_column :certificates, :extensions, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_17_153312) do
+ActiveRecord::Schema.define(version: 2021_11_18_140430) do
 
   create_table "audits", charset: "utf8", force: :cascade do |t|
     t.integer "auditable_id"
@@ -45,6 +45,7 @@ ActiveRecord::Schema.define(version: 2021_11_17_153312) do
     t.string "category", null: false
     t.text "issuer"
     t.text "serial"
+    t.text "extensions"
   end
 
   create_table "clients", charset: "utf8", force: :cascade do |t|

--- a/spec/acceptance/certificate/view_certificate_spec.rb
+++ b/spec/acceptance/certificate/view_certificate_spec.rb
@@ -34,6 +34,7 @@ describe "showing a certificate", type: :feature do
         expect(page).to have_content certificate.subject
         expect(page).to have_content certificate.issuer
         expect(page).to have_content certificate.serial
+        expect(page).to have_content certificate.extensions
       end
     end
   end

--- a/spec/factories/certificate.rb
+++ b/spec/factories/certificate.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     sequence(:subject) { |n| "Certificate subject #{n}" }
     sequence(:issuer) { |n| "Certificate issuer #{n}" }
     sequence(:serial) { |n| "Certificate serial #{n}" }
+    sequence(:extensions) { |n| "Certificate extensions #{n}" }
     sequence(:filename) { |n| "ca#{n}.pem" }
     category { "EAP" }
   end

--- a/spec/use_cases/read_certificate_metadata_spec.rb
+++ b/spec/use_cases/read_certificate_metadata_spec.rb
@@ -33,6 +33,23 @@ describe UseCases::ReadCertificateMetadata do
       expected_serial = "261449075976929706890225671845538541127278523818"
       expect(serial).to eq expected_serial
     end
+
+    it "extracts the extensions of the certificate" do
+      extensions = use_case.call[:extensions]
+      expected_extensions = <<~EXTENSIONS
+        subjectKeyIdentifier:
+        \t46:53:FE:BC:50:C0:5D:02:B5:24:1B:BA:B3:B8:E2:89:87:85:40:08
+
+        authorityKeyIdentifier:
+        \tkeyid:46:53:FE:BC:50:C0:5D:02:B5:24:1B:BA:B3:B8:E2:89:87:85:40:08
+
+
+        basicConstraints: critical
+        \tCA:TRUE
+      EXTENSIONS
+
+      expect(extensions).to eq expected_extensions.strip
+    end
   end
 
   context "when the certificate is invalid" do


### PR DESCRIPTION
## Context

- This shows all of the extensions associated with a certificate (`*.pem`)
- This will display the `Subject-Alt-Name` details as well
- Uses `sanitize` to display the extensions in a formatted way as shown

<img width="983" alt="image" src="https://user-images.githubusercontent.com/47318342/142603229-3145bdef-02e8-42b9-8407-ccd52ad42c74.png">