### PR TITLE
Persist site and policy count when saving

### DIFF
--- a/app/models/site_policy.rb
+++ b/app/models/site_policy.rb
@@ -2,5 +2,15 @@ class SitePolicy < ApplicationRecord
   belongs_to :site
   belongs_to :policy
 
+  after_create :update_site_count, :update_policy_count
+
   audited
+
+  def update_site_count
+    policy.update_attribute(:site_count, policy.sites.count)
+  end
+
+  def update_policy_count
+    site.update_attribute(:policy_count, site.policies.count)
+  end
 end

--- a/db/migrate/20211123095714_add_site_count_to_policies.rb
+++ b/db/migrate/20211123095714_add_site_count_to_policies.rb
@@ -1,0 +1,5 @@
+class AddSiteCountToPolicies < ActiveRecord::Migration[6.1]
+  def change
+    add_column :policies, :site_count, :bigint, null: true, default: 0
+  end
+end

--- a/db/migrate/20211123102659_add_policy_count_to_sites.rb
+++ b/db/migrate/20211123102659_add_policy_count_to_sites.rb
@@ -1,0 +1,5 @@
+class AddPolicyCountToSites < ActiveRecord::Migration[6.1]
+  def change
+    add_column :sites, :policy_count, :bigint, null: true, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_18_140430) do
+ActiveRecord::Schema.define(version: 2021_11_23_102659) do
 
   create_table "audits", charset: "utf8", force: :cascade do |t|
     t.integer "auditable_id"
@@ -73,6 +73,7 @@ ActiveRecord::Schema.define(version: 2021_11_18_140430) do
     t.datetime "updated_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.boolean "fallback", default: false, null: false
     t.integer "rule_count", default: 0
+    t.bigint "site_count", default: 0
   end
 
   create_table "responses", charset: "utf8", force: :cascade do |t|
@@ -109,6 +110,7 @@ ActiveRecord::Schema.define(version: 2021_11_18_140430) do
     t.datetime "created_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.datetime "updated_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.string "tag", null: false
+    t.bigint "policy_count", default: 0
   end
 
   create_table "users", charset: "utf8", force: :cascade do |t|

--- a/spec/models/policy_spec.rb
+++ b/spec/models/policy_spec.rb
@@ -14,4 +14,12 @@ describe Policy, type: :model do
   it { is_expected.to have_many(:responses) }
   it { is_expected.to have_many(:site_policy) }
   it { is_expected.to have_many(:sites) }
+
+  it "persists the site count" do
+    policy = create(:policy)
+    expect(policy.site_count).to eq(0)
+
+    policy.sites << create(:site)
+    expect(policy.site_count).to eq(1)
+  end
 end

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -32,6 +32,14 @@ RSpec.describe Site, type: :model do
     expect(site.site_policy.where(site_id: site.id, policy_id: fallback_policy_id).first).to be_nil
   end
 
+  it "persists the policy count" do
+    site = create(:site)
+    expect(site.policy_count).to eq(1)
+
+    site.policies << create(:policy)
+    expect(site.policy_count).to eq(2)
+  end
+
   context "when there is a policy with the same name" do
     let!(:policy_with_same_name) { create(:policy, name: "Fallback policy for My site") }
 


### PR DESCRIPTION
This prevents N+1 queries when calculating this in memory.