### PR TITLE
Fix: Session timeout results in Admin portal crash

### DIFF
--- a/app/controllers/mab_responses_controller.rb
+++ b/app/controllers/mab_responses_controller.rb
@@ -1,6 +1,7 @@
 class MabResponsesController < ApplicationController
   before_action :set_mac_authentication_bypass, only: %i[new create destroy edit update]
   before_action :set_crumbs, only: %i[new edit destroy]
+  before_action :redirect_to_mac_authentication_bypasses_path, only: :index
 
   def new
     @response = MabResponse.new
@@ -59,6 +60,8 @@ class MabResponsesController < ApplicationController
     end
   end
 
+  def index; end
+
 private
 
   def mac_authentication_bypass_id
@@ -96,5 +99,9 @@ private
         mac_authentication_bypasses: MacAuthenticationBypass.all,
       ),
     )
+  end
+
+  def redirect_to_mac_authentication_bypasses_path
+    redirect_to mac_authentication_bypasses_path
   end
 end

--- a/app/controllers/policy_responses_controller.rb
+++ b/app/controllers/policy_responses_controller.rb
@@ -1,6 +1,7 @@
 class PolicyResponsesController < ApplicationController
   before_action :set_policy, only: %i[new create destroy edit update]
   before_action :set_crumbs, only: %i[new edit destroy]
+  before_action :redirect_to_policies_path, only: :index
 
   def new
     @response = PolicyResponse.new
@@ -50,6 +51,8 @@ class PolicyResponsesController < ApplicationController
     end
   end
 
+  def index; end
+
 private
 
   def policy_id
@@ -72,5 +75,9 @@ private
 
   def set_crumbs
     @navigation_crumbs << ["Policies", policies_path]
+  end
+
+  def redirect_to_policies_path
+    redirect_to policies_path
   end
 end

--- a/app/controllers/rules_controller.rb
+++ b/app/controllers/rules_controller.rb
@@ -51,6 +51,8 @@ class RulesController < ApplicationController
     end
   end
 
+  def index; end
+
 private
 
   def policy_id
@@ -72,7 +74,7 @@ private
   end
 
   def redirect_to_policies_path
-    redirect_to policies_path if @policy.fallback?
+    redirect_to policies_path if @policy.nil? || @policy.fallback?
   end
 
   def set_crumbs


### PR DESCRIPTION
### Context 

After a session timeout on Rules/Responses pages, Rails tries to render `index` which results in:
![Screenshot 2021-11-24 at 15 55 57](https://user-images.githubusercontent.com/22743709/143287296-b546b145-3e76-4334-89a1-61f47a8888a1.png)

