### PR TITLE
Redirect to the sign in page before rendering a 404 page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,6 +22,16 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def error
+    if user_signed_in?
+      respond_to do |format|
+        format.html { render file: "#{Rails.root}/public/404.html", status: :not_found }
+      end
+    else
+      redirect_to new_user_session_path
+    end
+  end
+
 protected
 
   def deploy_service

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,12 +21,14 @@ Rails.application.routes.draw do
   post "/sites/:id/policies/update", to: "sites#update_site_policies", as: "update_site_policies"
 
   resources :policies do
-    resources :rules
-    resources :policy_responses
+    resources :rules, except: :index
+    resources :policy_responses, except: :index
   end
 
   get "/healthcheck", to: "monitoring#healthcheck"
 
   root "home#index"
   resources :audits, only: %i[index show]
+
+  match "*path", via: :all, to: "application#error"
 end

--- a/spec/acceptance/sign_in_spec.rb
+++ b/spec/acceptance/sign_in_spec.rb
@@ -8,6 +8,11 @@ RSpec.describe "GET /sign_in", type: :feature do
     expect(page).to have_content "Sign in"
   end
 
+  it "displays sign in when not signed in and route is not found" do
+    visit "/some-undefined-route"
+    expect(page).to have_content "Sign in"
+  end
+
   context "user signed in" do
     before do
       # Simulate logging in via Cognito Omniauth provider


### PR DESCRIPTION
If a user is not signed in, we don't want to allow them to learn any
existent / non-existent routes. Always redirect to sign in before
rendering a page not found.