### PR TITLE
Order MABs by site

### DIFF
--- a/app/controllers/mac_authentication_bypasses_controller.rb
+++ b/app/controllers/mac_authentication_bypasses_controller.rb
@@ -5,7 +5,7 @@ class MacAuthenticationBypassesController < ApplicationController
 
   def index
     @q = MacAuthenticationBypass.ransack(params[:q])
-    @mac_authentication_bypasses = @q.result.page(params.dig(:q, :page))
+    @mac_authentication_bypasses = @q.result.includes(:site).page(params.dig(:q, :page))
   end
 
   def new

--- a/app/views/mac_authentication_bypasses/index.html.erb
+++ b/app/views/mac_authentication_bypasses/index.html.erb
@@ -26,7 +26,7 @@
         <th scope="col" class="govuk-table__header"><%= sort_link(@q, :description) %></th>
         <th scope="col" class="govuk-table__header"><%= sort_link(@q, :created_at, "Created") %></th>
         <th scope="col" class="govuk-table__header"><%= sort_link(@q, :updated_at, "Updated") %></th>
-        <th scope="col" class="govuk-table__header"><%= sort_link(@q, :site) %></th>
+        <th scope="col" class="govuk-table__header"><%= sort_link(@q, :site_name, "Site") %></th>
         <th scope="col" class="govuk-table__header govuk-table__narrow">
           <span class="govuk-visually-hidden"></span>
         </th>

--- a/app/views/mac_authentication_bypasses/index.html.erb
+++ b/app/views/mac_authentication_bypasses/index.html.erb
@@ -26,6 +26,7 @@
         <th scope="col" class="govuk-table__header"><%= sort_link(@q, :description) %></th>
         <th scope="col" class="govuk-table__header"><%= sort_link(@q, :created_at, "Created") %></th>
         <th scope="col" class="govuk-table__header"><%= sort_link(@q, :updated_at, "Updated") %></th>
+        <th scope="col" class="govuk-table__header"><%= sort_link(@q, :site) %></th>
         <th scope="col" class="govuk-table__header govuk-table__narrow">
           <span class="govuk-visually-hidden"></span>
         </th>
@@ -39,6 +40,8 @@
           <td class="govuk-table__cell"><%= bypass.description %></td>
           <td class="govuk-table__cell"><%= date_format(bypass.created_at) %></td>
           <td class="govuk-table__cell"><%= date_format(bypass.updated_at) %></td>
+          <td class="govuk-table__cell">
+            <%=  bypass.site ? link_to("#{bypass.site.try(:name)}", site_path(bypass.site), class: "govuk-link") : "-" %>
           <td class="govuk-table__cell">
             <% if can? :manage, MacAuthenticationBypass %>
               <%= link_to "Manage", mac_authentication_bypass_path(bypass), class:"govuk-link" %>

--- a/spec/acceptance/mac_authentication_bypass/list_spec.rb
+++ b/spec/acceptance/mac_authentication_bypass/list_spec.rb
@@ -6,7 +6,7 @@ describe "showing a MAC authentication bypass", type: :feature do
   end
 
   context "when the MAC authentication bypasses exists" do
-    let!(:mac_authentication_bypass) { create :mac_authentication_bypass, site: create(:site) }
+    let!(:mac_authentication_bypass) { create :mac_authentication_bypass }
 
     it "allows viewing bypasses" do
       visit "/mac_authentication_bypasses"
@@ -16,7 +16,30 @@ describe "showing a MAC authentication bypass", type: :feature do
       expect(page).to have_content mac_authentication_bypass.description
       expect(page).to have_content date_format(mac_authentication_bypass.created_at)
       expect(page).to have_content date_format(mac_authentication_bypass.updated_at)
-      expect(page).to have_content mac_authentication_bypass.site.name
+    end
+  end
+
+  context "when the MAC authentication bypasses exists with sites" do
+    let!(:a_mab) { create :mac_authentication_bypass, address: "aa-11-22-33-44-11", site: create(:site, name: "AAA") }
+    let!(:b_mab) { create :mac_authentication_bypass, address: "aa-11-22-33-44-12", site: create(:site, name: "BBB") }
+
+    it "allows ordering bypasses by site names" do
+      visit "/mac_authentication_bypasses"
+
+      expect(page).to have_content a_mab.site.name
+      expect(page).to have_content b_mab.site.name
+
+      within ".govuk-grid-row" do
+        first(:link, "Site").click
+      end
+
+      expect(page.text).to match(/#{a_mab.name}.*#{b_mab.name}/)
+
+      within ".govuk-grid-row" do
+        first(:link, "Site").click
+      end
+
+      expect(page.text).to match(/#{b_mab.name}.*#{a_mab.name}/)
     end
   end
 end

--- a/spec/acceptance/mac_authentication_bypass/list_spec.rb
+++ b/spec/acceptance/mac_authentication_bypass/list_spec.rb
@@ -6,7 +6,7 @@ describe "showing a MAC authentication bypass", type: :feature do
   end
 
   context "when the MAC authentication bypasses exists" do
-    let!(:mac_authentication_bypass) { create :mac_authentication_bypass }
+    let!(:mac_authentication_bypass) { create :mac_authentication_bypass, site: create(:site) }
 
     it "allows viewing bypasses" do
       visit "/mac_authentication_bypasses"
@@ -16,6 +16,7 @@ describe "showing a MAC authentication bypass", type: :feature do
       expect(page).to have_content mac_authentication_bypass.description
       expect(page).to have_content date_format(mac_authentication_bypass.created_at)
       expect(page).to have_content date_format(mac_authentication_bypass.updated_at)
+      expect(page).to have_content mac_authentication_bypass.site.name
     end
   end
 end


### PR DESCRIPTION
### Context
We implemented ordering on the MABs page, but since that, a new `site` field has been added.
Changes in this PR:
- Add site field to the list
- Allow ordering using site field

### UI
![image](https://user-images.githubusercontent.com/22743709/144089680-765430eb-1b24-4153-bc7b-defe4a03fc1f.png)
