### PR TITLE
Attach policy to multiple sites

### DIFF
--- a/app/views/policies/policy_sites.html.erb
+++ b/app/views/policies/policy_sites.html.erb
@@ -1,0 +1,37 @@
+<h2 class="govuk-heading-l"><%= @policy.name %></h2>
+<%= search_form_for @q, url: policy_sites_path do |f| %>
+  <%= f.search_field :name_cont, class: "govuk-input govuk-input--width-10", id: "search" %>
+
+  <%= f.submit "Search", { class: "govuk-button", "data-module" => "govuk-button" } %>
+<% end %>
+<%= form_with local: true do |f| %>
+  <div class="govuk-form-group">
+    <fieldset class="govuk-fieldset" aria-describedby="attach-policies-hint">
+      <div id="attach-policies-hint" class="govuk-hint">
+        Select sites for this policy to be attached to.
+      </div>
+      <div class="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
+        <% policy_sites_ids = @policy.sites.map { |site| site.id } %>
+        <%= f.hidden_field :filtered_site_ids, value: @sites.map(&:id) %>
+        <%= f.collection_check_boxes :site_ids, @sites, :id, :name do |b| %>
+          <div class="govuk-checkboxes__item">
+            <%= b.check_box class: "govuk-checkboxes__input", checked: policy_sites_ids.include?(b.object.id) %>
+            <%= b.label class: "govuk-label govuk-checkboxes__label" %>
+          </div>
+        <% end %>
+      </div>
+    </fieldset>
+  </div>
+
+  <%= f.submit "Update", {
+    class: "govuk-button",
+    "data-module" => "govuk-button"
+  } %>
+
+  <%= link_to "Cancel", @policy,
+  class: "govuk-button govuk-button--secondary",
+  data: {
+    module: "govuk-button"
+  } %>
+
+<% end %>

--- a/app/views/policies/show.html.erb
+++ b/app/views/policies/show.html.erb
@@ -33,7 +33,7 @@
   <%= link_to "Add response", new_policy_policy_response_path(policy_id: @policy), class: "govuk-button" %>
 <% end %>
 
-<% if can? :manage, Policy %>
+<% if (can? :manage, Policy) && !@policy.fallback %>
   <%= link_to "Manage sites", policy_sites_path(policy_id: @policy), class: "govuk-button" %>
 <% end %>
 

--- a/app/views/policies/show.html.erb
+++ b/app/views/policies/show.html.erb
@@ -15,6 +15,14 @@
       <% end %>
     </dd>
   </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">Sites</dt>
+    <dd class="govuk-summary-list__value"><%= @policy.site_count %></dd>
+    <dd class="govuk-summary-list__actions">
+      <%= link_to sites_path(:q => { :policy_id => @policy.id }), class: "govuk-link" do %>
+        View<span class="govuk-visually-hidden"> sites</span>
+      <% end %>
+  </div>
 </dl>
 
 <% if (can? :create, Rule) && !@policy.fallback %>

--- a/app/views/policies/show.html.erb
+++ b/app/views/policies/show.html.erb
@@ -25,6 +25,10 @@
   <%= link_to "Add response", new_policy_policy_response_path(policy_id: @policy), class: "govuk-button" %>
 <% end %>
 
+<% if can? :manage, Policy %>
+  <%= link_to "Manage sites", policy_sites_path(policy_id: @policy), class: "govuk-button" %>
+<% end %>
+
 <% if @policy.rules.any? %>
   <table class="govuk-table">
     <caption class="govuk-table__caption">List of rules</caption>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,9 @@ Rails.application.routes.draw do
   get "/sites/:id/policies/edit", to: "sites#edit_site_policies", as: "edit_site_policies"
   post "/sites/:id/policies/update", to: "sites#update_site_policies", as: "update_site_policies"
 
+  get "/policies/:id/sites", to: "policies#policy_sites", as: "policy_sites"
+  post "/policies/:id/sites", to: "policies#attach_policy_sites", as: "attach_policy_sites"
+
   resources :policies do
     resources :rules, except: :index
     resources :policy_responses, except: :index

--- a/spec/acceptance/policy/attach_sites_spec.rb
+++ b/spec/acceptance/policy/attach_sites_spec.rb
@@ -62,6 +62,16 @@ describe "attach sites to a policy", type: :feature do
         expect(page).to have_content(second_site.name)
         expect(page).to_not have_content(site.name)
       end
+
+      context "when there is a fallback policy" do
+        it "does not allow attaching sites" do
+          visit "/sites/#{site.id}"
+
+          click_on "Fallback policy for #{site.name}"
+
+          expect(page).to_not have_content("Manage sites")
+        end
+      end
     end
   end
 end

--- a/spec/acceptance/policy/attach_sites_spec.rb
+++ b/spec/acceptance/policy/attach_sites_spec.rb
@@ -41,6 +41,12 @@ describe "attach sites to a policy", type: :feature do
         click_on "Update"
 
         expect(page).to have_content("Successfully attached policy to sites.")
+
+        click_on policy.name
+
+        expect(page).to have_content("Sites")
+        expect(page).to have_content("1")
+        expect(page).to have_link("View", href: "/sites?q%5Bpolicy_id%5D=#{policy.id}")
       end
 
       it "does allow searching sites" do

--- a/spec/acceptance/policy/attach_sites_spec.rb
+++ b/spec/acceptance/policy/attach_sites_spec.rb
@@ -19,4 +19,28 @@ describe "attach sites to a policy", type: :feature do
       end
     end
   end
+
+  context "when the user is an editor" do
+    before do
+      login_as create(:user, :editor)
+    end
+
+    context "when both site and non-fallback policies exist" do
+      let!(:site) { create :site, name: "First Site" }
+      let!(:policy) { create :policy }
+
+      it "does allow attaching sites to a policy" do
+        visit "/policies"
+
+        find_link("Manage", href: "/policies/#{policy.id}").click
+        find_link("Manage sites", href: "/policies/#{policy.id}/sites?policy_id=#{policy.id}").click
+
+        check "First Site", allow_label_click: true
+
+        click_on "Update"
+
+        expect(page).to have_content("Successfully attached policy to sites.")
+      end
+    end
+  end
 end

--- a/spec/acceptance/policy/attach_sites_spec.rb
+++ b/spec/acceptance/policy/attach_sites_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+describe "attach sites to a policy", type: :feature do
+  context "when the user is a reader" do
+    before do
+      login_as create(:user, :reader)
+    end
+
+    context "when both site and policy exists" do
+      let!(:site) { create :site }
+      let!(:policy) { create :policy }
+
+      it "does not allow attaching policies to a site" do
+        visit "/policies"
+
+        click_on "View", match: :first
+
+        expect(page).to_not have_content "Manage sites"
+      end
+    end
+  end
+end

--- a/spec/acceptance/policy/attach_sites_spec.rb
+++ b/spec/acceptance/policy/attach_sites_spec.rb
@@ -27,6 +27,7 @@ describe "attach sites to a policy", type: :feature do
 
     context "when both site and non-fallback policies exist" do
       let!(:site) { create :site, name: "First Site" }
+      let!(:second_site) { create :site, name: "Second Site" }
       let!(:policy) { create :policy }
 
       it "does allow attaching sites to a policy" do
@@ -40,6 +41,20 @@ describe "attach sites to a policy", type: :feature do
         click_on "Update"
 
         expect(page).to have_content("Successfully attached policy to sites.")
+      end
+
+      it "does allow searching sites" do
+        visit "/policies"
+
+        find_link("Manage", href: "/policies/#{policy.id}").click
+        find_link("Manage sites", href: "/policies/#{policy.id}/sites?policy_id=#{policy.id}").click
+
+        fill_in "search", with: "Second"
+
+        click_on "Search"
+
+        expect(page).to have_content(second_site.name)
+        expect(page).to_not have_content(site.name)
       end
     end
   end


### PR DESCRIPTION
## Context

- Allow attaching of multiple sites to policies
- `Manage sites` button is not displayed for fallback policies
- Sites can be filtered using the search feature
- The number of sites that the policy is attached to is displayed below the description
  - The `View` link will display a page with the list of sites that the policy is attached to

<img width="990" alt="image" src="https://user-images.githubusercontent.com/47318342/145013474-bf97abfa-9966-4377-98f2-de3419f172e3.png">

<img width="398" alt="image" src="https://user-images.githubusercontent.com/47318342/145013702-028ba85b-5dd2-4a57-840d-5f3ae8e1b00b.png">

<img width="384" alt="image" src="https://user-images.githubusercontent.com/47318342/145013767-7f7f9445-31a0-4346-af97-cf59ad412050.png">
