### PR TITLE
Naming convention

### DIFF
--- a/app/views/mac_authentication_bypasses/_form.html.erb
+++ b/app/views/mac_authentication_bypasses/_form.html.erb
@@ -10,6 +10,10 @@
 
   <div class="govuk-form-group <%= field_error(f.object, :name) %>">
     <%= f.label :name, class: "govuk-label" %>
+    <div id="name-hint" class="govuk-hint">
+      Must contain the make, model, and hostname in the following format: "MAKE_MODEL_HOSTNAME"<br />
+      For example: XEROX_7835_MFD001
+    </div>
     <%= f.text_field :name, class: "govuk-input" %>
   </div>
 

--- a/app/views/policies/_form.html.erb
+++ b/app/views/policies/_form.html.erb
@@ -1,6 +1,10 @@
 <%= form_with model: policy, local: true do |f| %>
   <div class="govuk-form-group <%= field_error(f.object, :name) %>">
     <%= f.label :name, class: "govuk-label" %>
+    <div id="name-hint" class="govuk-hint">
+      Must contain the usage, environment, and VLAN ID in the following format: "USAGE_ENVIRONMENT_VLANXXX"<br />
+      For example: MOJO_LAN_VLAN101, or DOM1_MOJWIFI_VLAN102
+    </div>
     <%= f.text_field :name, class: "govuk-input" %>
   </div>
 

--- a/app/views/sites/_form.html.erb
+++ b/app/views/sites/_form.html.erb
@@ -1,6 +1,10 @@
 <%= form_with model: site, local: true do |f| %>
   <div class="govuk-form-group <%= field_error(f.object, :name) %>">
     <%= f.label :name, class: "govuk-label" %>
+    <div id="name-hint" class="govuk-hint">
+      Must contain the FITS ID, and location in the following format: "FITS_XXX_LOCATION"<br />
+      For example: FITS_4591_MAIDSTONE
+    </div>
     <%= f.text_field :name, class: "govuk-input" %>
   </div>
 


### PR DESCRIPTION
## Context

- Add hint text for MAB, Policy, and Site naming conventions

```
MAB Name - "MAKE_MODEL_HOSTNAME" = "XEROX_7835_MFD001",

Policy Name - "USAGE_ENVIRONMENT_VLANXXX" = "MOJO_LAN_VLAN601" / "DOM1_MOJWIFI_VLAN602"

Site Name - "FITS_XXX_LOCATION" = "FITS_4591_MAIDSTONE"
```