### PR TITLE
Validate all FreeRadius configuration files before publishing to S3

### DIFF
--- a/app/controllers/certificates_controller.rb
+++ b/app/controllers/certificates_controller.rb
@@ -82,18 +82,20 @@ private
   end
 
   def publish_certificate(certificate_file, filename)
-    p "start cert upload"
+    content = certificate_file.to_io
+
     UseCases::PublishToS3.new(
+      config_validator: UseCases::ConfigValidator.new(
+        config_file_path: "/etc/raddb/certs/#{@certificate.filename}",
+        content: content,
+      ),
       destination_gateway: Gateways::S3.new(
         bucket: ENV.fetch("RADIUS_CERTIFICATE_BUCKET_NAME"),
         key: full_object_path(filename),
         aws_config: Rails.application.config.s3_aws_config,
         content_type: "text/plain",
       ),
-    ).call(
-      certificate_file.to_io,
-    )
-    p "done uploading cert"
+    ).call(content)
   end
 
   def full_object_path(filename)

--- a/app/controllers/clients_controller.rb
+++ b/app/controllers/clients_controller.rb
@@ -78,19 +78,23 @@ private
   end
 
   def publish_authorised_clients
+    content = UseCases::GenerateAuthorisedClients.new.call(
+      clients: Client.where.not(shared_secret: "radsec").includes(:site),
+      radsec_clients: Client.where(shared_secret: "radsec").includes(:site),
+    )
+
     UseCases::PublishToS3.new(
+      config_validator: UseCases::ConfigValidator.new(
+        config_file_path: "/etc/raddb/clients.conf",
+        content: content,
+      ),
       destination_gateway: Gateways::S3.new(
         bucket: ENV.fetch("RADIUS_CONFIG_BUCKET_NAME"),
         key: "clients.conf",
         aws_config: Rails.application.config.s3_aws_config,
         content_type: "text/plain",
       ),
-    ).call(
-      UseCases::GenerateAuthorisedClients.new.call(
-        clients: Client.where.not(shared_secret: "radsec").includes(:site),
-        radsec_clients: Client.where(shared_secret: "radsec").includes(:site),
-      ),
-    )
+    ).call(content)
   end
 
   def set_crumbs

--- a/app/controllers/mab_responses_controller.rb
+++ b/app/controllers/mab_responses_controller.rb
@@ -84,17 +84,21 @@ private
   end
 
   def publish_authorised_macs
+    content = UseCases::GenerateAuthorisedMacs.new.call(
+      mac_authentication_bypasses: MacAuthenticationBypass.all,
+    )
+
     UseCases::PublishToS3.new(
+      config_validator: UseCases::ConfigValidator.new(
+        config_file_path: "/etc/raddb/mods-config/files/authorize",
+        content: content,
+      ),
       destination_gateway: Gateways::S3.new(
         bucket: ENV.fetch("RADIUS_CONFIG_BUCKET_NAME"),
         key: "authorised_macs",
         aws_config: Rails.application.config.s3_aws_config,
         content_type: "text/plain",
       ),
-    ).call(
-      UseCases::GenerateAuthorisedMacs.new.call(
-        mac_authentication_bypasses: MacAuthenticationBypass.all,
-      ),
-    )
+    ).call(content)
   end
 end

--- a/app/controllers/mac_authentication_bypasses_controller.rb
+++ b/app/controllers/mac_authentication_bypasses_controller.rb
@@ -78,18 +78,20 @@ private
   end
 
   def publish_authorised_macs
+    content = UseCases::GenerateAuthorisedMacs.new.call(mac_authentication_bypasses: MacAuthenticationBypass.all)
+
     UseCases::PublishToS3.new(
+      config_validator: UseCases::ConfigValidator.new(
+        config_file_path: "/etc/raddb/mods-config/files/authorize",
+        content: content,
+      ),
       destination_gateway: Gateways::S3.new(
         bucket: ENV.fetch("RADIUS_CONFIG_BUCKET_NAME"),
         key: "authorised_macs",
         aws_config: Rails.application.config.s3_aws_config,
         content_type: "text/plain",
       ),
-    ).call(
-      UseCases::GenerateAuthorisedMacs.new.call(
-        mac_authentication_bypasses: MacAuthenticationBypass.all,
-      ),
-    )
+    ).call(content)
   end
 
   def set_crumbs

--- a/app/lib/use_cases/config_validator.rb
+++ b/app/lib/use_cases/config_validator.rb
@@ -21,7 +21,7 @@ module UseCases
     end
 
     def clean_up_tmp_config_files
-      [ "/etc/raddb/clients.conf", "/etc/raddb/mods-config/files/authorize", config_file_path ].each { |f| File.write(f, "") }
+      ["/etc/raddb/clients.conf", "/etc/raddb/mods-config/files/authorize", config_file_path].each { |f| File.write(f, "") }
     end
 
     def result

--- a/app/lib/use_cases/config_validator.rb
+++ b/app/lib/use_cases/config_validator.rb
@@ -1,0 +1,41 @@
+module UseCases
+  class ConfigValidator
+    def initialize(config_file_path:, content:)
+      @config_file_path = config_file_path
+      @content = content
+    end
+
+    def call
+      clean_up_tmp_config_files
+      write_tmp_config_file
+
+      abort("Corrupt FreeRadius configuration: #{parsed_error}") unless configuration_ok?
+    ensure
+      clean_up_tmp_config_files
+    end
+
+  private
+
+    def write_tmp_config_file
+      File.write(config_file_path, content)
+    end
+
+    def clean_up_tmp_config_files
+      [ "/etc/raddb/clients.conf", "/etc/raddb/mods-config/files/authorize", config_file_path ].each { |f| File.write(f, "") }
+    end
+
+    def result
+      @result ||= `/usr/sbin/radiusd -CX`
+    end
+
+    def parsed_error
+      result.split("\n").select { |l| l.match(/error(.*)/) }.first.split(":")[1, 2].join(":").strip
+    end
+
+    def configuration_ok?
+      result.match?(/Configuration appears to be OK/)
+    end
+
+    attr_reader :content, :config_file_path
+  end
+end

--- a/app/lib/use_cases/generate_authorised_macs.rb
+++ b/app/lib/use_cases/generate_authorised_macs.rb
@@ -1,7 +1,7 @@
 class UseCases::GenerateAuthorisedMacs
   def call(mac_authentication_bypasses:)
     bypasses = mac_authentication_bypasses.map do |bypass|
-      responses = bypass.responses.map { |response| [response.response_attribute, response.value].join(" = ") }.join(",\n        ")
+      responses = bypass.responses.map { |response| [response.response_attribute, "\"#{response.value}\""].join(" = ") }.join(",\n        ")
       bypass_address_line = "#{bypass.address} Cleartext-Password := #{normalised_password(bypass.address)}"
 
       bypass.responses.empty? ? bypass_address_line : [bypass_address_line, responses].join("\n        ")

--- a/app/lib/use_cases/publish_to_s3.rb
+++ b/app/lib/use_cases/publish_to_s3.rb
@@ -1,13 +1,19 @@
 class UseCases::PublishToS3
-  def initialize(destination_gateway:)
+  def initialize(destination_gateway:, config_validator:)
     @destination_gateway = destination_gateway
+    @config_validator = config_validator
   end
 
   def call(config)
+    validate_config!
     destination_gateway.write(data: config)
   end
 
 private
 
-  attr_reader :destination_gateway
+  def validate_config!
+    config_validator.call
+  end
+
+  attr_reader :destination_gateway, :config_validator
 end

--- a/spec/acceptance/clients/create_clients_spec.rb
+++ b/spec/acceptance/clients/create_clients_spec.rb
@@ -5,6 +5,7 @@ describe "create clients", type: :feature do
     let(:editor) { create(:user, :editor) }
     let(:publish_to_s3) { instance_double(UseCases::PublishToS3) }
     let(:s3_gateway) { double(Gateways::S3) }
+    let(:config_validator) { double(UseCases::ConfigValidator) }
 
     before do
       login_as editor
@@ -29,7 +30,12 @@ describe "create clients", type: :feature do
         expect_service_deployment
 
         expect(Gateways::S3).to receive(:new).with(expected_s3_gateway_config).and_return(s3_gateway)
-        expect(UseCases::PublishToS3).to receive(:new).with(destination_gateway: s3_gateway).and_return(publish_to_s3)
+        expect(UseCases::ConfigValidator).to receive(:new).and_return(config_validator)
+
+        expect(UseCases::PublishToS3).to receive(:new).with(
+          destination_gateway: s3_gateway,
+          config_validator: config_validator,
+        ).and_return(publish_to_s3)
 
         visit "/sites/#{site.id}"
 
@@ -63,7 +69,12 @@ clients radsec {
 
       it "creates a new RadSec client" do
         expect(Gateways::S3).to receive(:new).with(expected_s3_gateway_config).and_return(s3_gateway)
-        expect(UseCases::PublishToS3).to receive(:new).with(destination_gateway: s3_gateway).and_return(publish_to_s3)
+        expect(UseCases::ConfigValidator).to receive(:new).and_return(config_validator)
+
+        expect(UseCases::PublishToS3).to receive(:new).with(
+          destination_gateway: s3_gateway,
+          config_validator: config_validator,
+        ).and_return(publish_to_s3)
 
         expect_service_deployment
 

--- a/spec/acceptance/clients/delete_clients_spec.rb
+++ b/spec/acceptance/clients/delete_clients_spec.rb
@@ -28,6 +28,7 @@ describe "delete clients", type: :feature do
       let!(:client) { create(:client, site: site) }
       let(:publish_to_s3) { instance_double(UseCases::PublishToS3) }
       let(:s3_gateway) { double(Gateways::S3) }
+      let(:config_validator) { double(UseCases::ConfigValidator) }
 
       it "deletes an existing client" do
         expect_service_deployment
@@ -42,7 +43,11 @@ describe "delete clients", type: :feature do
         }
 
         expect(Gateways::S3).to receive(:new).with(expected_s3_gateway_config).and_return(s3_gateway)
-        expect(UseCases::PublishToS3).to receive(:new).with(destination_gateway: s3_gateway).and_return(publish_to_s3)
+        expect(UseCases::ConfigValidator).to receive(:new).and_return(config_validator)
+        expect(UseCases::PublishToS3).to receive(:new).with(
+          destination_gateway: s3_gateway,
+          config_validator: config_validator,
+        ).and_return(publish_to_s3)
 
         visit "/sites/#{site.id}"
 

--- a/spec/acceptance/clients/update_clients_spec.rb
+++ b/spec/acceptance/clients/update_clients_spec.rb
@@ -5,6 +5,7 @@ describe "update clients", type: :feature do
   let(:client) { create(:client, site: site) }
   let(:publish_to_s3) { instance_double(UseCases::PublishToS3) }
   let(:s3_gateway) { double(Gateways::S3) }
+  let(:config_validator) { double(UseCases::ConfigValidator) }
 
   context "when the user is unauthenticated" do
     it "does not allow updating clients" do
@@ -51,7 +52,11 @@ describe "update clients", type: :feature do
       }
 
       expect(Gateways::S3).to receive(:new).with(expected_s3_gateway_config).and_return(s3_gateway)
-      expect(UseCases::PublishToS3).to receive(:new).with(destination_gateway: s3_gateway).and_return(publish_to_s3)
+      expect(UseCases::ConfigValidator).to receive(:new).and_return(config_validator)
+      expect(UseCases::PublishToS3).to receive(:new).with(
+        destination_gateway: s3_gateway,
+        config_validator: config_validator,
+      ).and_return(publish_to_s3)
 
       visit "sites/#{site.id}"
 

--- a/spec/use_cases/config_validator_spec.rb
+++ b/spec/use_cases/config_validator_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+describe UseCases::ConfigValidator do
+  let(:config_file_path) { "/etc/raddb/mods-config/files/authorize" }
+
+  context "with a valid configuration" do
+    it "does not raise an error" do
+      expect { described_class.new(config_file_path: config_file_path, content: "").call }.to_not raise_error
+    end
+  end
+
+  context "with an invalid configration" do
+    it "raises an error" do
+      expect { described_class.new(config_file_path: config_file_path, content: "something invalid").call }.to raise_error
+    end
+  end
+end

--- a/spec/use_cases/generate_authorised_macs_spec.rb
+++ b/spec/use_cases/generate_authorised_macs_spec.rb
@@ -36,12 +36,12 @@ describe UseCases::GenerateAuthorisedMacs do
 
         it "generates an authorised_macs configuration file" do
           expected_config = %(aa-66-77-88-99-00 Cleartext-Password := aa6677889900
-        Tunnel-Medium-Type = IEEE-802,
-        Tunnel-Private-Group-Id = 123456
+        Tunnel-Medium-Type = "IEEE-802",
+        Tunnel-Private-Group-Id = "123456"
 
 bb-cc-00-11-22-33 Cleartext-Password := bbcc00112233
-        Tunnel-Medium-Type = IEEE-802,
-        Tunnel-Private-Group-Id = 123456
+        Tunnel-Medium-Type = "IEEE-802",
+        Tunnel-Private-Group-Id = "123456"
 )
 
           expect(result).to eq(expected_config)

--- a/spec/use_cases/publish_to_s3_spec.rb
+++ b/spec/use_cases/publish_to_s3_spec.rb
@@ -1,21 +1,36 @@
 require "rails_helper"
 
+class FakeValidConfigValidator
+  def initialize(config_file_path:, contents:); end
+  def call() = nil
+end
+
+class FakeInvalidConfigValidator
+  def initialize(config_file_path:, contents:); end
+  def call() = abort("error")
+end
+
 describe UseCases::PublishToS3 do
-  subject(:use_case) do
-    described_class.new(
-      destination_gateway: s3_gateway,
-    )
-  end
-
   let(:s3_gateway) { instance_spy(Gateways::S3) }
-  let(:config) { "any file contents" }
+  let(:config) { "some file contents" }
 
-  before do
-    use_case.call(config)
+  subject(:use_case) { described_class.new(destination_gateway: s3_gateway, config_validator: config_validator) }
+
+  context "with a valid configuration" do
+    let(:config_validator) { FakeValidConfigValidator.new(config_file_path: "/something", contents: "stub") }
+
+    it "publishes the file with contents" do
+      use_case.call(config)
+      expect(s3_gateway).to have_received(:write).with(data: config)
+    end
   end
 
-  it "publishes the file with contents" do
-    expect(s3_gateway).to have_received(:write)
-      .with(data: config)
+  context "with an invalid configuration" do
+    let(:config_validator) { FakeInvalidConfigValidator.new(config_file_path: "/something", contents: "stub") }
+
+    it "does not publish the file with contents" do
+      expect { use_case.call(config) }.to raise_error(SystemExit)
+      expect(s3_gateway).to_not have_received(:write).with(data: config)
+    end
   end
 end


### PR DESCRIPTION
Use FreeRadius in addition to rails/model validations to ensure maximum
safeguarding before pushing a file to S3 and issuing a deployment
command.

This includes:
  1. client.conf
  2. MAB authorize
  3. certificates

If this validation fails, it is treated as an exception, meaning no
error will be surfaced to the user but the engineers will be notified.