### PR TITLE
Don't parse Freeradius error messages

### DIFF
--- a/app/lib/use_cases/config_validator.rb
+++ b/app/lib/use_cases/config_validator.rb
@@ -29,7 +29,7 @@ module UseCases
     end
 
     def parsed_error
-      result.split("\n").select { |l| l.match(/error(.*)/) }.first.split(":")[1, 2].join(":").strip
+      result.split("\n").last(5).join("\n")
     end
 
     def configuration_ok?

--- a/spec/use_cases/config_validator_spec.rb
+++ b/spec/use_cases/config_validator_spec.rb
@@ -11,7 +11,7 @@ describe UseCases::ConfigValidator do
 
   context "with an invalid configration" do
     it "raises an error" do
-      expect { described_class.new(config_file_path: config_file_path, content: "something invalid").call }.to raise_error
+      expect { described_class.new(config_file_path: config_file_path, content: "something invalid").call }.to raise_error(SystemExit)
     end
   end
 end


### PR DESCRIPTION
These messages are not consistent. Print last 5 lines of error logs
which can be used to diagnose. This should be exceptional behaviour and
not frequently encountered unless Rails validations were missed.