### PR TITLE
Validate IP range on client update

### DIFF
--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -2,7 +2,7 @@ class Client < ApplicationRecord
   belongs_to :site
 
   validates_presence_of :ip_range, :shared_secret
-  validate :validate_ip, on: :create
+  validate :validate_ip, on: %i[create update]
   validates :ip_range, presence: true, uniqueness: { scope: :radsec }
 
 private

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -36,4 +36,14 @@ describe Client, type: :model do
       expect(result).to be_invalid
     end
   end
+
+  it "validates an updated IP range" do
+    editable_client = create(:client)
+
+    expect(editable_client).to be_truthy
+
+    editable_client.update(ip_range: "Something-Invalid")
+
+    expect(editable_client).to be_invalid
+  end
 end


### PR DESCRIPTION
## Context

- When updating a client with a new IP address/range, the application validates the IP range