### PR TITLE
Ensure overlapping subnet CIDR blocks are not allowed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem "sentry-rails"
 gem "sentry-ruby"
 gem "sprockets", "~> 4.0.2"
 gem "tzinfo-data"
+gem "ip", "~> 0.3.1"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem "aws-sdk-ecs", "~> 1.92"
 gem "aws-sdk-s3", "~> 1.109"
 gem "cancancan", "~> 3.3"
 gem "devise"
+gem "ip", "~> 0.3.1"
 gem "ipaddress_2"
 gem "kaminari"
 gem "mysql2", "~> 0.5.3"
@@ -22,7 +23,6 @@ gem "sentry-rails"
 gem "sentry-ruby"
 gem "sprockets", "~> 4.0.2"
 gem "tzinfo-data"
-gem "ip", "~> 0.3.1"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,6 +145,7 @@ GEM
     hashie (4.1.0)
     i18n (1.8.11)
       concurrent-ruby (~> 1.0)
+    ip (0.3.1)
     ipaddr (1.2.2)
     ipaddress_2 (0.14.0)
     jmespath (1.4.0)
@@ -363,6 +364,7 @@ DEPENDENCIES
   devise
   dotenv-rails
   factory_bot_rails
+  ip (~> 0.3.1)
   ipaddress_2
   kaminari
   mysql2 (~> 0.5.3)

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -10,7 +10,15 @@ private
   def validate_ip
     return if ip_range.blank?
 
-    errors.add(:ip_range, "is invalid") unless IPAddress.valid_ipv4_subnet?(ip_range)
+    unless IPAddress.valid_ipv4_subnet?(ip_range)
+      return errors.add(:ip_range, "is invalid")
+    end
+
+    Client.all.each do |client|
+      if IP::CIDR.new(ip_range).overlaps?(IP::CIDR.new(client.ip_range))
+        return errors.add(:ip_range, "IP overlaps with #{client.site.name} - #{client.ip_range}")
+      end
+    end
   end
 
   audited

--- a/spec/acceptance/clients/list_clients_spec.rb
+++ b/spec/acceptance/clients/list_clients_spec.rb
@@ -7,10 +7,9 @@ describe "listing clients", type: :feature do
 
   context "when a site has clients" do
     let!(:client) { create :client }
-    let!(:site) { create :site, clients: [client] }
 
     it "allows viewing clients" do
-      visit "/sites/#{site.id}"
+      visit "/sites/#{client.site.id}"
 
       expect(page).to have_content client.ip_range
       expect(page).to have_content date_format(client.created_at)

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -46,4 +46,12 @@ describe Client, type: :model do
 
     expect(editable_client).to be_invalid
   end
+
+  it "does not allow overlapping IPs" do
+    ip1 = "127.0.0.1/32"
+    ip2 = "127.0.0.1/16"
+
+    create(:client, ip_range: ip1)
+    expect(build(:client, ip_range: ip2)).to be_invalid
+  end
 end


### PR DESCRIPTION
Overlapping subnet ranges would cause unexpected behaviour where the
smallest subnet takes presedence. This would lead to the wrong site tag
being used, and the wrong policies assigned.

Prevent this by raising an error if an overlapping subnet is created.