### PR TITLE
Allow searching by IP on sites page

### DIFF
--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -12,7 +12,7 @@
       <th scope="col" class="govuk-table__header search_bar">
         <%= search_form_for @q do |f| %>
           <%= f.hidden_field :policy_id, value: @policy_id %>
-          <%= f.search_field :name_cont, class: 'govuk-input govuk-input--width-10' %>
+          <%= f.search_field :name_or_clients_ip_range_cont, class: 'govuk-input govuk-input--width-10' %>
 
           <%= f.submit "Search", { class: "govuk-button", "data-module" => "govuk-button" } %>
         <% end %>

--- a/spec/acceptance/policy/list_policies_spec.rb
+++ b/spec/acceptance/policy/list_policies_spec.rb
@@ -45,7 +45,7 @@ describe "showing a policy", type: :feature do
       expect(page).to have_content "For policy: #{policy.name}"
       expect(page).to_not have_content "Create a new site"
 
-      fill_in "q_name_cont", with: "site 2"
+      fill_in "q_name_or_clients_ip_range_cont", with: "site 2"
 
       click_on "Search"
 

--- a/spec/acceptance/sites/list_sites_spec.rb
+++ b/spec/acceptance/sites/list_sites_spec.rb
@@ -27,6 +27,7 @@ describe "listing sites", type: :feature do
     end
 
     context "searching and ordering" do
+      let!(:client) { create(:client, ip_range: "10.0.1.222/32") }
       let!(:first_site) { create(:site, name: "AA Site") }
       let!(:second_site) { create(:site, name: "BB Site") }
       let!(:third_site) { create(:site, name: "Site AAA") }
@@ -39,12 +40,21 @@ describe "listing sites", type: :feature do
         expect(page).to have_content first_site.name
         expect(page).to have_content second_site.name
 
-        fill_in "q_name_cont", with: "AA"
+        fill_in "q_name_or_clients_ip_range_cont", with: "AA"
         click_on "Search"
 
         expect(page).to_not have_content second_site.name
         expect(page).to have_content first_site.name
         expect(page).to have_content third_site.name
+      end
+
+      it "searches by client ip address" do
+        fill_in "q_name_or_clients_ip_range_cont", with: "10.0.1"
+        click_on "Search"
+
+        expect(page).to have_content client.site.name
+        expect(page).to_not have_content second_site.name
+        expect(page).to_not have_content third_site.name
       end
 
       it "orders by name" do


### PR DESCRIPTION
We can search by site name but there is no way to find a site by the
client ip ranges contained in that site.