### PR TITLE
Exclude current client from subnet overlap check

### DIFF
--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -14,7 +14,8 @@ private
       return errors.add(:ip_range, "is invalid")
     end
 
-    Client.all.each do |client|
+    existing_clients = id.present? ? Client.where.not(id: id) : Client.all
+    existing_clients.each do |client|
       if IP::CIDR.new(ip_range).overlaps?(IP::CIDR.new(client.ip_range))
         return errors.add(:ip_range, "IP overlaps with #{client.site.name} - #{client.ip_range}")
       end

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -47,11 +47,20 @@ describe Client, type: :model do
     expect(editable_client).to be_invalid
   end
 
-  it "does not allow overlapping IPs" do
-    ip1 = "127.0.0.1/32"
-    ip2 = "127.0.0.1/16"
+  context "creating a client" do
+    it "does not allow overlapping IPs" do
+      ip1 = "127.0.0.1/32"
+      ip2 = "127.0.0.1/16"
 
-    create(:client, ip_range: ip1)
-    expect(build(:client, ip_range: ip2)).to be_invalid
+      create(:client, ip_range: ip1)
+      expect(build(:client, ip_range: ip2)).to be_invalid
+    end
+  end
+
+  context "updating a client" do
+    it "does allow updating the existing client ip" do
+      client = create(:client)
+      expect { client.save! }.to_not raise_error
+    end
   end
 end


### PR DESCRIPTION
Currently prevents saving an existing record because it detects it as a
overlapping cidr