### PR TITLE
Pull base images directly from Dockerhub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG SHARED_SERVICES_ACCOUNT_ID
-FROM ${SHARED_SERVICES_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com/admin:ruby-3-0-2-alpine3-14
+FROM ruby:3.0.2-alpine3.14
+
 ARG UID=1001
 ARG GROUP=app
 ARG USER=app

--- a/Makefile
+++ b/Makefile
@@ -8,14 +8,11 @@ BUNDLE_FLAGS=
 
 DOCKER_BUILD_CMD = BUNDLE_INSTALL_FLAGS="$(BUNDLE_FLAGS)" $(DOCKER_COMPOSE) build
 
-authenticate-docker: check-container-registry-account-id
+authenticate-docker:
 	./scripts/authenticate_docker.sh
 
-check-container-registry-account-id:
-	./scripts/check_container_registry_account_id.sh
-
-build: check-container-registry-account-id
-	docker build -t admin . --build-arg RACK_ENV --build-arg DB_HOST --build-arg DB_USER --build-arg DB_PORT --build-arg DB_PASS --build-arg SECRET_KEY_BASE --build-arg DB_NAME --build-arg BUNDLE_WITHOUT --build-arg SHARED_SERVICES_ACCOUNT_ID --build-arg CLOUDWATCH_LINK
+build:
+	docker build -t admin . --build-arg RACK_ENV --build-arg DB_HOST --build-arg DB_USER --build-arg DB_PORT --build-arg DB_PASS --build-arg SECRET_KEY_BASE --build-arg DB_NAME --build-arg BUNDLE_WITHOUT --build-arg CLOUDWATCH_LINK
 
 build-dev:
 	$(DOCKER_COMPOSE) build
@@ -74,4 +71,4 @@ lint:
 implode:
 	$(DOCKER_COMPOSE) rm
 
-.PHONY: build serve stop test deploy migrate migrate-dev build-dev push publish implode authenticate-docker check-container-registry-account-id start-db db-setup run shell lint bootstrap integration-test clone-integration-test
+.PHONY: build serve stop test deploy migrate migrate-dev build-dev push publish implode authenticate-docker start-db db-setup run shell lint bootstrap integration-test clone-integration-test

--- a/README.md
+++ b/README.md
@@ -4,23 +4,25 @@ This is the web frontend for managing Network Access Control
 
 ## Getting Started
 
-### Authenticating Docker with AWS ECR
+### Authenticating with DockerHub
 
-The Docker base image is stored in ECR. Prior to building the container you must authenticate Docker to the ECR registry. [Details can be found here](https://docs.aws.amazon.com/AmazonECR/latest/userguide/Registries.html#registry_auth).
 
-If you have [aws-vault](https://github.com/99designs/aws-vault#installing) configured with credentials for shared services, do the following to authenticate:
+Local development shouldn't go over the download limits of Dockerhub.
+https://docs.docker.com/docker-hub/download-rate-limit/
 
-```bash
-aws-vault exec SHARED_SERVICES_VAULT_PROFILE_NAME -- aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin SHARED_SERVICES_ACCOUNT_ID.dkr.ecr.eu-west-2.amazonaws.com
+If these limits are encountered, authenticating with Docker is required:
+
 ```
+export DOCKER_USERNAME=your-docker-hub-username
+export DOCKER_PASSWORD=your-docker-hub-password
 
-Replace ```SHARED_SERVICES_VAULT_PROFILE_NAME``` and ```SHARED_SERVICES_ACCOUNT_ID``` in the command above with the profile name and ID of the shared services account configured in aws-vault.
+make authenticate-docker
+```
 
 ### Starting the App
 
 1. Clone the repository
 1. Create a `.env` file in the root directory
-   1. Add `SHARED_SERVICES_ACCOUNT_ID=` to the `.env` file, entering the relevant account ID
 1. If this is the first time you have setup the project:
 
    1. Build the base containers

--- a/buildspec.test.yml
+++ b/buildspec.test.yml
@@ -6,8 +6,8 @@ env:
     ENV: test
     RACK_ENV: test
   parameter-store:
-    ROLE_ARN: /codebuild/pttp-ci-infrastructure-core-pipeline/development/assume_role # tests hardcoded to only run in development
-    SHARED_SERVICES_ACCOUNT_ID: /codebuild/staff_device_shared_services_account_id
+    DOCKER_USERNAME: "/moj-network-access-control/docker/username"
+    DOCKER_PASSWORD: "/moj-network-access-control/docker/password"
 
 phases:
   install:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -16,7 +16,8 @@ env:
     TERRAFORM_OUTPUTS: "/moj-network-access-control/terraform/$ENV/outputs"
     TARGET_AWS_ACCOUNT_ID: "/codebuild/$ENV/account_id"
     ROLE_ARN: "/codebuild/pttp-ci-infrastructure-core-pipeline/${ENV}/assume_role"
-    SHARED_SERVICES_ACCOUNT_ID: /codebuild/staff_device_shared_services_account_id
+    DOCKER_USERNAME: "/moj-network-access-control/docker/username"
+    DOCKER_PASSWORD: "/moj-network-access-control/docker/password"
     CLOUDWATCH_LINK: "/moj-network-access-control/$ENV/cloudwatch_link"
 
 phases:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   db:
-    image: "${SHARED_SERVICES_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com/admin-mysql:mysql-5-7"
+    image: mysql:5.7
     env_file: .env.${ENV}
     expose:
       - "3306"
@@ -19,7 +19,6 @@ services:
       args:
         UID: "${UID}"
         BUNDLE_INSTALL_FLAGS: "${BUNDLE_INSTALL_FLAGS:- --jobs 20 --retry 5}"
-        SHARED_SERVICES_ACCOUNT_ID: "${SHARED_SERVICES_ACCOUNT_ID}"
     user: "${UID}:${UID}"
     command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
     volumes:

--- a/scripts/authenticate_docker.sh
+++ b/scripts/authenticate_docker.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-set -euo pipefail
+set -eu pipefail
 
-aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin ${SHARED_SERVICES_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com
+docker login --username ${DOCKER_USERNAME} --password ${DOCKER_PASSWORD}

--- a/scripts/check_container_registry_account_id.sh
+++ b/scripts/check_container_registry_account_id.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-set -euo pipefail
-
-if [ -z ${SHARED_SERVICES_ACCOUNT_ID} ]; then
-  echo "Please set enviroment variable SHARED_SERVICES_ACCOUNT_ID for shared services";
-  exit 1;
-fi


### PR DESCRIPTION
The MoJ Docker organisation has acquired licenses, which means we
don't need to manage our own base images anymore.

Developers can authenticate locally (and shouldn't get rate limited),
and CI will authenticate with service credentials.