### PR TITLE
Extend MAB Import

### DIFF
--- a/app/controllers/mac_authentication_bypasses_imports_controller.rb
+++ b/app/controllers/mac_authentication_bypasses_imports_controller.rb
@@ -6,7 +6,8 @@ class MacAuthenticationBypassesImportsController < ApplicationController
   end
 
   def create
-    contents = mac_authentication_bypasses_import_params[:bypasses].read
+    contents = mac_authentication_bypasses_import_params&.dig(:bypasses)&.read
+
     @mac_authentication_bypasses_import = MacAuthenticationBypassesImport.new(contents)
 
     if @mac_authentication_bypasses_import.save
@@ -21,6 +22,8 @@ class MacAuthenticationBypassesImportsController < ApplicationController
 private
 
   def mac_authentication_bypasses_import_params
+    return if params[:mac_authentication_bypasses_import].nil?
+
     params.require(:mac_authentication_bypasses_import).permit(:bypasses)
   end
 

--- a/app/models/mac_authentication_bypasses_import.rb
+++ b/app/models/mac_authentication_bypasses_import.rb
@@ -9,16 +9,16 @@ class MacAuthenticationBypassesImport
   include ActiveModel::Conversion
   include ActiveModel::Naming
 
-  validate :validate_header
+  validate :validate_csv
   validate :validate_records
   validate :validate_sites
 
-  def initialize(csv_contents = {})
+  def initialize(csv_contents = nil)
     @csv_contents = csv_contents
     @records = []
     @sites_not_found = []
 
-    return if csv_contents.empty? || !valid_header?
+    return unless valid_header?
 
     CSV.parse(csv_contents, headers: true).each do |row|
       address = row["Address"]
@@ -62,7 +62,9 @@ class MacAuthenticationBypassesImport
 
 private
 
-  def validate_header
+  def validate_csv
+    return errors.add(:base, "CSV is missing") if @csv_contents.nil?
+
     errors.add(:base, "The CSV header is invalid") unless valid_header?
   end
 
@@ -92,6 +94,8 @@ private
   end
 
   def valid_header?
+    return false if @csv_contents.nil?
+
     @csv_contents.split("\n").first == CSV_HEADERS
   end
 end

--- a/app/models/mac_authentication_bypasses_import.rb
+++ b/app/models/mac_authentication_bypasses_import.rb
@@ -71,8 +71,15 @@ private
   def validate_records
     @records.each_with_index do |record, i|
       record.validate
+
       record.errors.full_messages.each do |message|
         errors.add(:base, "Error on row #{i + 2}: #{message}")
+      end
+
+      record.responses.each do |response|
+        response.errors.full_messages.each do |message|
+          errors.add(:base, "Error on row #{i + 2}: #{message}")
+        end
       end
     end
   end

--- a/app/models/mac_authentication_bypasses_import.rb
+++ b/app/models/mac_authentication_bypasses_import.rb
@@ -69,17 +69,17 @@ private
   end
 
   def validate_records
-    @records.each do |record|
+    @records.each_with_index do |record, i|
       record.validate
       record.errors.full_messages.each do |message|
-        errors.add(:base, message)
+        errors.add(:base, "Error on row #{i + 2}: #{message}")
       end
     end
   end
 
   def validate_sites
     @sites_not_found.each do |site_name|
-      errors.add(:base, "Site #{site_name} is not found")
+      errors.add(:base, "Site \"#{site_name}\" is not found")
     end
   end
 

--- a/app/models/mac_authentication_bypasses_import.rb
+++ b/app/models/mac_authentication_bypasses_import.rb
@@ -60,6 +60,10 @@ class MacAuthenticationBypassesImport
     false
   end
 
+  def headers
+    CSV_HEADERS
+  end
+
 private
 
   def validate_csv

--- a/app/views/mac_authentication_bypasses_imports/new.html.erb
+++ b/app/views/mac_authentication_bypasses_imports/new.html.erb
@@ -4,7 +4,12 @@
   <h2 class="govuk-heading-l">Import bypasses</h2>
 
   <div class="govuk-form-group">
-    <%= f.label :bypasses, class: "govuk-label" %>
+    <div id="csv-hint" class="govuk-hint">
+      Header must contain the following: "<%= @mac_authentication_bypasses_import.headers %>"<br /><br />
+      Responses must be separated by a semicolon.<br />
+      For example: Tunnel-Type=VLAN;Reply-Message=Welcome;SG-Tunnel-Id=333<br /><br />
+      File must have extension of ".csv"<br />
+    </div>
     <%= f.file_field :bypasses, class: "govuk-file-upload" %>
   </div>
 

--- a/app/views/mac_authentication_bypasses_imports/new.html.erb
+++ b/app/views/mac_authentication_bypasses_imports/new.html.erb
@@ -1,25 +1,6 @@
 <%= render "layouts/form_errors", resource: @mac_authentication_bypasses_import %>
 
 <%= form_with model: @mac_authentication_bypasses_import, local: true do |f| %>
-  <% f.object.records.each do |record| %>
-    <% next unless record.errors.any? %>
-    <div class="govuk-form-group govuk-form-group--error">
-      <dl class="govuk-summary-list">
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">MAC Address</dt>
-          <dd class="govuk-summary-list__value"><%= record.address %></dd>
-          <dt class="govuk-summary-list__key">Name</dt>
-          <dd class="govuk-summary-list__value"><%= record.name %></dd>
-        </div>
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">Description</dt>
-          <dd class="govuk-summary-list__value"><%= record.description %></dd>
-          <dt class="govuk-summary-list__key">Site</dt>
-          <dd class="govuk-summary-list__value"><%= record.site&.name %></dd>
-        </div>
-      </dl>
-    </div>
-  <% end %>
   <h2 class="govuk-heading-l">Import bypasses</h2>
 
   <div class="govuk-form-group">

--- a/spec/acceptance/mac_authentication_bypass/bulk_upload_mab_spec.rb
+++ b/spec/acceptance/mac_authentication_bypass/bulk_upload_mab_spec.rb
@@ -103,8 +103,8 @@ describe "bulk upload MAC Authentication Bypasses", type: :feature do
 
       expect(page).to have_content("There is a problem")
 
-      expect(page).to have_content("Address is invalid")
-      expect(page).to have_content("Site Unknown Site is not found")
+      expect(page).to have_content("Error on row 2: Address is invalid")
+      expect(page).to have_content("Site \"Unknown Site\" is not found")
     end
 
     it "shows errors when the CSV is missing" do

--- a/spec/acceptance/mac_authentication_bypass/bulk_upload_mab_spec.rb
+++ b/spec/acceptance/mac_authentication_bypass/bulk_upload_mab_spec.rb
@@ -106,5 +106,17 @@ describe "bulk upload MAC Authentication Bypasses", type: :feature do
       expect(page).to have_content("Address is invalid")
       expect(page).to have_content("Site Unknown Site is not found")
     end
+
+    it "shows errors when the CSV is missing" do
+      visit "/mac_authentication_bypasses"
+
+      click_on "Import bypasses"
+
+      expect(current_path).to eql("/mac_authentication_bypasses_imports/new")
+
+      click_on "Upload"
+
+      expect(page).to have_content("CSV is missing")
+    end
   end
 end

--- a/spec/models/mac_authentication_bypasses_import_spec.rb
+++ b/spec/models/mac_authentication_bypasses_import_spec.rb
@@ -61,7 +61,7 @@ aa-bb-cc-dd-ee-ff,Printer1,some test,Tunnel-Type=VLAN;Reply-Message=Hello to you
   context "csv with invalid entries" do
     let(:file_contents) do
       "Address,Name,Description,Responses,Site
-aa-bb-cc-dd-ee-ffff,Printer3,some test3,Tunnel-Type=VLAN,Unknown Site"
+aa-bb-cc-dd-ee-ffff,Printer3,some test3,Tunnel-Type=VLAN;3Com-Connect_Id=ASASAS,Unknown Site"
     end
 
     it "records the validation errors" do
@@ -69,6 +69,8 @@ aa-bb-cc-dd-ee-ffff,Printer3,some test3,Tunnel-Type=VLAN,Unknown Site"
       expect(subject.errors.full_messages).to eq(
         [
           "Error on row 2: Address is invalid",
+          "Error on row 2: Responses is invalid",
+          "Error on row 2: 3com-connect id Unknown or invalid value \"ASASAS\" for attribute 3Com-Connect_Id",
           "Site \"Unknown Site\" is not found",
         ],
       )

--- a/spec/models/mac_authentication_bypasses_import_spec.rb
+++ b/spec/models/mac_authentication_bypasses_import_spec.rb
@@ -68,8 +68,8 @@ aa-bb-cc-dd-ee-ffff,Printer3,some test3,Tunnel-Type=VLAN,Unknown Site"
       expect(subject).to_not be_valid
       expect(subject.errors.full_messages).to eq(
         [
-          "Address is invalid",
-          "Site Unknown Site is not found",
+          "Error on row 2: Address is invalid",
+          "Site \"Unknown Site\" is not found",
         ],
       )
     end


### PR DESCRIPTION
## Context

- display errors in the appropriate format when:
  - addresses are invalid
  - responses are invalid
  - sites are not found
  - CSV file is missing
  - CSV has invalid headers
- display errors with the corresponding row number
- add GOV.UK hint text on MAB import page for CSV format

### MAB import page 
<img width="688" alt="image" src="https://user-images.githubusercontent.com/47318342/146931659-2d55b610-e41e-4447-9fd7-9f9f740df55b.png">

### MAB import errors
<img width="983" alt="image" src="https://user-images.githubusercontent.com/47318342/146931784-007f8c56-ffb2-4506-b916-d2cde29da1a7.png">
