### PR TITLE
Improve performance on generating the MAC Authentication Bypass file

### DIFF
--- a/app/controllers/mac_authentication_bypasses_controller.rb
+++ b/app/controllers/mac_authentication_bypasses_controller.rb
@@ -78,7 +78,7 @@ private
   end
 
   def publish_authorised_macs
-    content = UseCases::GenerateAuthorisedMacs.new.call(mac_authentication_bypasses: MacAuthenticationBypass.all)
+    content = UseCases::GenerateAuthorisedMacs.new.call(mac_authentication_bypasses: MacAuthenticationBypass.includes(:responses).all)
 
     UseCases::PublishToS3.new(
       config_validator: UseCases::ConfigValidator.new(

--- a/app/controllers/mac_authentication_bypasses_imports_controller.rb
+++ b/app/controllers/mac_authentication_bypasses_imports_controller.rb
@@ -28,7 +28,7 @@ private
   end
 
   def publish_authorised_macs
-    content = UseCases::GenerateAuthorisedMacs.new.call(mac_authentication_bypasses: MacAuthenticationBypass.all)
+    content = UseCases::GenerateAuthorisedMacs.new.call(mac_authentication_bypasses: MacAuthenticationBypass.includes(:responses).all)
 
     UseCases::PublishToS3.new(
       config_validator: UseCases::ConfigValidator.new(

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -26,6 +26,5 @@ phases:
       - make authenticate-docker
       - make publish
       - make migrate
-      - make seed
       - make bootstrap
       - make deploy

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -66,7 +66,6 @@ ActiveRecord::Schema.define(version: 2021_12_23_100646) do
     t.datetime "updated_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.bigint "site_id"
     t.index ["address"], name: "index_mac_authentication_bypasses_on_address"
-    t.index ["address"], name: "mac_index"
     t.index ["site_id"], name: "index_mac_authentication_bypasses_on_site_id"
   end
 
@@ -116,7 +115,6 @@ ActiveRecord::Schema.define(version: 2021_12_23_100646) do
     t.string "tag", null: false
     t.bigint "policy_count", default: 0
     t.index ["name"], name: "index_sites_on_name"
-    t.index ["name"], name: "site_name_index"
   end
 
   create_table "users", charset: "utf8", force: :cascade do |t|


### PR DESCRIPTION
Preload responses before calling usecase. This reduces the number of database calls.