### PR TITLE
Don't display duplicate results

### DIFF
--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -13,7 +13,7 @@ class SitesController < ApplicationController
            Site.ransack(params[:q])
          end
 
-    @sites = @q.result.page(params.dig(:q, :page))
+    @sites = @q.result(distinct: true).page(params.dig(:q, :page))
   end
 
   def show; end


### PR DESCRIPTION
Use distinct to only pull back exact matches