### PR TITLE
Suppress abort error message in Rspec

### DIFF
--- a/spec/use_cases/config_validator_spec.rb
+++ b/spec/use_cases/config_validator_spec.rb
@@ -12,7 +12,7 @@ describe UseCases::ConfigValidator do
   context "with an invalid configration" do
     before do
       @orig_stderr = $stderr
-      $stderr = File.new('/dev/null', 'w')
+      $stderr = File.new("/dev/null", "w")
     end
 
     after { $stderr = @orig_stderr }

--- a/spec/use_cases/config_validator_spec.rb
+++ b/spec/use_cases/config_validator_spec.rb
@@ -10,6 +10,13 @@ describe UseCases::ConfigValidator do
   end
 
   context "with an invalid configration" do
+    before do
+      @orig_stderr = $stderr
+      $stderr = File.new('/dev/null', 'w')
+    end
+
+    after { $stderr = @orig_stderr }
+
     it "raises an error" do
       expect { described_class.new(config_file_path: config_file_path, content: "something invalid").call }.to raise_error(SystemExit)
     end


### PR DESCRIPTION
Make spec output more readable.
This temporarily disables STDERR to not print the abort exception to the
terminal.