### PR TITLE
Redirect to login page when user session has timed out

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ group :test do
   gem "capybara", ">= 2.15"
   gem "selenium-webdriver"
   gem "shoulda-matchers", "~> 5.1"
+  gem "timecop"
   gem "webdrivers"
   gem "webmock"
-  gem "timecop"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -40,4 +40,5 @@ group :test do
   gem "shoulda-matchers", "~> 5.1"
   gem "webdrivers"
   gem "webmock"
+  gem "timecop"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -325,6 +325,7 @@ GEM
       sprockets (>= 3.0.0)
     thor (1.1.0)
     tilt (2.0.10)
+    timecop (0.9.4)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     tzinfo-data (1.2021.5)
@@ -380,6 +381,7 @@ DEPENDENCIES
   sentry-ruby
   shoulda-matchers (~> 5.1)
   sprockets (~> 4.0.2)
+  timecop
   tzinfo-data
   webdrivers
   webmock

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,5 +1,15 @@
 require "omni_auth/strategies/cognito"
 
+class CustomFailure < Devise::FailureApp
+  def redirect_url
+     new_user_session_url
+  end
+
+  def respond
+    redirect
+  end
+end
+
 # Assuming you have not yet modified this file, each configuration option below
 # is set to its default value. Note that some are commented out while others
 # are not: uncommented lines are intended to protect your configuration from
@@ -275,6 +285,10 @@ Devise.setup do |config|
                                                                                     user_pool_id: ENV["COGNITO_USER_POOL_ID"],
                                                                                     aws_region: "eu-west-2", strategy_class: OmniAuth::Strategies::Cognito
   config.omniauth :developer
+
+  config.warden do |manager|
+    manager.failure_app = CustomFailure
+  end
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -2,7 +2,7 @@ require "omni_auth/strategies/cognito"
 
 class CustomFailure < Devise::FailureApp
   def redirect_url
-     new_user_session_url
+    new_user_session_url
   end
 
   def respond

--- a/spec/acceptance/mac_authentication_bypass/responses/update_responses_spec.rb
+++ b/spec/acceptance/mac_authentication_bypass/responses/update_responses_spec.rb
@@ -3,3 +3,29 @@ require "rails_helper"
 describe "update responses", type: :feature do
   it_behaves_like "response update", :mac_authentication_bypass, :mab_response, "mab_response_response_attribute"
 end
+
+describe "logged out response update attempt", type: :feature do
+  let(:editor) { create(:user, :editor) }
+  let!(:mab_response) { create(:mab_response)}
+
+  before do
+    login_as editor
+  end
+
+  it "redirects to the login page" do
+    visit new_mac_authentication_bypass_mab_response_path(mac_authentication_bypass_id: mab_response.mac_authentication_bypass.id)
+
+    select mab_response.response_attribute, from: "mab_response_response_attribute"
+    fill_in "Value", with: mab_response.value
+
+    click_on "Create"
+
+    expect(page).to have_content("Response attribute has already been added")
+
+    Timecop.travel(Time.now + 6 * 60)
+
+    click_on "Create"
+
+    expect(page.current_url).to eq(new_user_session_url)
+  end
+end

--- a/spec/acceptance/mac_authentication_bypass/responses/update_responses_spec.rb
+++ b/spec/acceptance/mac_authentication_bypass/responses/update_responses_spec.rb
@@ -22,7 +22,7 @@ describe "logged out response update attempt", type: :feature do
 
     expect(page).to have_content("Response attribute has already been added")
 
-    Timecop.travel(Time.now + 6 * 60)
+    Timecop.travel(6.minutes.from_now)
 
     click_on "Create"
 

--- a/spec/acceptance/mac_authentication_bypass/responses/update_responses_spec.rb
+++ b/spec/acceptance/mac_authentication_bypass/responses/update_responses_spec.rb
@@ -6,7 +6,7 @@ end
 
 describe "logged out response update attempt", type: :feature do
   let(:editor) { create(:user, :editor) }
-  let!(:mab_response) { create(:mab_response)}
+  let!(:mab_response) { create(:mab_response) }
 
   before do
     login_as editor


### PR DESCRIPTION
Currently renders a 404 page when the app is unable to authenticate the
user. Redirect to the login page instead with a custom Devise failure application.