### PR TITLE
Use Ransack for pagination of audit logs

### DIFF
--- a/app/controllers/audits_controller.rb
+++ b/app/controllers/audits_controller.rb
@@ -2,7 +2,8 @@ class AuditsController < ApplicationController
   before_action :set_crumbs, only: %i[index show]
 
   def index
-    @audits = Audit.order(created_at: "DESC").page params[:page]
+    @q = Audit.order(created_at: "DESC").ransack(params[:q])
+    @audits = @q.result.page(params.dig(:q, :page))
   end
 
   def show


### PR DESCRIPTION
Currently not able to click through the pages of the audit logs. This
will fix it.