### PR TITLE
Add validation for empty list of attributes

### DIFF
--- a/app/models/CSV_import/mac_authentication_bypasses.rb
+++ b/app/models/CSV_import/mac_authentication_bypasses.rb
@@ -90,6 +90,7 @@ module CSVImport
 
     def validate_csv
       return errors.add(:base, "CSV is missing") if @csv_contents.nil?
+      return errors.add(:base, "There is no data to be imported") unless @csv_contents.split("\n").second
 
       errors.add(:base, "The CSV header is invalid") unless valid_header?
     end

--- a/spec/models/CSV_import/mac_authentication_bypasses_spec.rb
+++ b/spec/models/CSV_import/mac_authentication_bypasses_spec.rb
@@ -60,6 +60,21 @@ aa-bb-cc-dd-ee-ff,Printer1,some test,Tunnel-Type=VLAN;Reply-Message=Hello to you
     end
   end
 
+  context "csv with empty list of attributes" do
+    let(:file_contents) do
+      "Address,Name,Description,Responses,Site"
+    end
+
+    it "records the validation errors" do
+      expect(subject).to_not be_valid
+      expect(subject.errors.full_messages).to eq(
+        [
+          "There is no data to be imported",
+        ],
+      )
+    end
+  end
+
   context "csv with invalid entries" do
     let(:file_contents) do
       "Address,Name,Description,Responses,Site


### PR DESCRIPTION
## Context

- Add validation for when there is no data in the CSV file when attempting to import MAC authentication data
  - the CSV file contains valid headers but no data
  - the previous behaviour resulted in a Rails error page (empty list of attributes)