### PR TITLE
MAB Import validation updates

### DIFF
--- a/app/models/CSV_import/mac_authentication_bypasses.rb
+++ b/app/models/CSV_import/mac_authentication_bypasses.rb
@@ -12,7 +12,7 @@ module CSVImport
 
     validate :validate_csv
     validate :validate_records
-    validate :validate_radius_attributes
+    validate :validate_radius_attributes, unless: -> { errors.any? }
     validate :validate_sites
 
     def initialize(csv_contents = nil)

--- a/app/models/CSV_import/mac_authentication_bypasses.rb
+++ b/app/models/CSV_import/mac_authentication_bypasses.rb
@@ -40,8 +40,11 @@ module CSVImport
         end
       end
 
-      MacAuthenticationBypass.insert_all(records_to_save)
-      MabResponse.insert_all(responses_to_save)
+      ActiveRecord::Base.transaction do
+        saved_records = MacAuthenticationBypass.insert_all(records_to_save)
+        MabResponse.insert_all(responses_to_save) unless responses_to_save.empty?
+        saved_records
+      end
     end
 
   private

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -34,7 +34,6 @@ end
 #   policy.responses.create!(response_attribute: "Reply-Message", value: "Hello there!")
 # end
 
-
 p "creating sites"
 750.times do |s|
   site = Site.create!(name: "NEW test site #{s}")

--- a/spec/models/CSV_import/mac_authentication_bypasses_spec.rb
+++ b/spec/models/CSV_import/mac_authentication_bypasses_spec.rb
@@ -75,7 +75,25 @@ aa-bb-cc-dd-ee-ff,Printer1,some test,Tunnel-Type=VLAN;Reply-Message=Hello to you
     end
   end
 
-  context "csv with invalid entries" do
+  context "csv with invalid content" do
+    let(:file_contents) do
+      "Address,Name,Description,Responses,Site
+
+aa-bb-cc-dd-ee-ff,Printer1,some test,Tunnel-Type=VLAN;Reply-Message=Hello to you;SG-Tunnel-Id=777,"
+    end
+
+    it "records the validation errors" do
+      expect(subject).to_not be_valid
+      expect(subject.errors.full_messages).to eq(
+        [
+          "Error on row 2: Address can't be blank",
+          "Error on row 2: Address is invalid",
+        ],
+      )
+    end
+  end
+
+  context "csv with invalid MAC address and unknown site" do
     let(:file_contents) do
       "Address,Name,Description,Responses,Site
 aa-bb-cc-dd-ee-ffff,Printer3,some test3,Tunnel-Type=VLAN;3Com-Connect_Id=ASASAS,Unknown Site"
@@ -86,7 +104,6 @@ aa-bb-cc-dd-ee-ffff,Printer3,some test3,Tunnel-Type=VLAN;3Com-Connect_Id=ASASAS,
       expect(subject.errors.full_messages).to eq(
         [
           "Error on row 2: Address is invalid",
-          "Error on row 2: Unknown or invalid value \"ASASAS\" for attribute 3Com-Connect_Id",
           "Site \"Unknown Site\" is not found",
         ],
       )
@@ -94,6 +111,22 @@ aa-bb-cc-dd-ee-ffff,Printer3,some test3,Tunnel-Type=VLAN;3Com-Connect_Id=ASASAS,
 
     it "does not save the records" do
       expect(subject.save).to be_falsey
+    end
+  end
+
+  context "csv with invalid response attribute" do
+    let(:file_contents) do
+      "Address,Name,Description,Responses,Site
+aa-bb-cc-dd-ee-ff,Printer3,some test3,Tunnel-Type=VLAN;3Com-Connect_Id=ASASAS,"
+    end
+
+    it "records the validation errors" do
+      expect(subject).to_not be_valid
+      expect(subject.errors.full_messages).to eq(
+        [
+          "Error on row 2: Unknown or invalid value \"ASASAS\" for attribute 3Com-Connect_Id",
+        ],
+      )
     end
   end
 

--- a/spec/models/CSV_import/mac_authentication_bypasses_spec.rb
+++ b/spec/models/CSV_import/mac_authentication_bypasses_spec.rb
@@ -44,6 +44,26 @@ cc-bb-cc-dd-ee-ff,Printer3,some test,Tunnel-Type=VLAN;Reply-Message=Hello to you
     end
   end
 
+  context "valid csv entries with no responses" do
+    let(:file_contents) do
+      "Address,Name,Description,Responses,Site
+bb-bb-cc-dd-ee-ff,Printer2,some test,,"
+    end
+
+    it "creates valid MABs" do
+      expect(subject).to be_valid
+      expect(subject.errors).to be_empty
+
+      expect(subject.save).to be_truthy
+      saved_bypass = MacAuthenticationBypass.last
+      expect(saved_bypass.id).to_not be_nil
+
+      saved_bypass.responses.each do |response|
+        expect(response.id).to be_nil
+      end
+    end
+  end
+
   context "csv with invalid header" do
     let(:file_contents) do
       "Description,Responses,Site


### PR DESCRIPTION
### Changes
- Suppress Radius attribute validation when record invalid
- Allow importing mac_authentication_bypasses with no responses 
- Use transaction when saving MABs and MABResponses