### PR TITLE
Ensure single error message is shown per field for MABs

### DIFF
--- a/app/models/CSV_import/mac_authentication_bypass.rb
+++ b/app/models/CSV_import/mac_authentication_bypass.rb
@@ -1,7 +1,7 @@
 module CSVImport
   class MacAuthenticationBypass < MacAuthenticationBypass
     def validate_uniqueness_of_address(list_of_mac_addresses)
-      errors.add(:address, "has already taken") unless list_of_mac_addresses.count(address) == 1
+      errors.add(:address, "has already taken") unless address.nil? || list_of_mac_addresses.count(address) == 1
     end
 
     def skip_uniqueness_validation?

--- a/app/models/mac_authentication_bypass.rb
+++ b/app/models/mac_authentication_bypass.rb
@@ -5,7 +5,7 @@ class MacAuthenticationBypass < ApplicationRecord
 
   validates :address, presence: true
   validates :address, uniqueness: true, unless: :skip_uniqueness_validation?
-  validates_format_of :address, with: /\A([0-9a-f]{2}-){5}([0-9a-f]{2})\z/, on: :create
+  validates_format_of :address, with: /\A([0-9a-f]{2}-){5}([0-9a-f]{2})\z/, on: :create, if: -> { address.present? }
 
   has_many :responses, dependent: :destroy
 

--- a/spec/models/CSV_import/mac_authentication_bypasses_spec.rb
+++ b/spec/models/CSV_import/mac_authentication_bypasses_spec.rb
@@ -95,6 +95,26 @@ aa-bb-cc-dd-ee-ff,Printer1,some test,Tunnel-Type=VLAN;Reply-Message=Hello to you
     end
   end
 
+  context "csv with empty lines" do
+    let(:file_contents) do
+      "Address,Name,Description,Responses,Site
+
+aa-bb-cc-dd-ee-ff,Printer1,some test,Tunnel-Type=VLAN;Reply-Message=Hello to you;SG-Tunnel-Id=777,
+
+aa-bb-cc-11-22-33,Printer2,some test,Tunnel-Type=VLAN;Reply-Message=Bye to you;SG-Tunnel-Id=888,"
+    end
+
+    it "records the validation errors" do
+      expect(subject).to_not be_valid
+      expect(subject.errors.full_messages).to eq(
+        [
+          "Error on row 2: Address can't be blank",
+          "Error on row 4: Address can't be blank",
+        ],
+      )
+    end
+  end
+
   context "csv with invalid content" do
     let(:file_contents) do
       "Address,Name,Description,Responses,Site
@@ -107,7 +127,6 @@ aa-bb-cc-dd-ee-ff,Printer1,some test,Tunnel-Type=VLAN;Reply-Message=Hello to you
       expect(subject.errors.full_messages).to eq(
         [
           "Error on row 2: Address can't be blank",
-          "Error on row 2: Address is invalid",
         ],
       )
     end


### PR DESCRIPTION
## Context 

- validate uniqueness of MAC addresses only when the MAC address is present
- validate format of MAC address when MAC address is present
