### PR TITLE
Don't force authenticating with Dockerhub

### DIFF
--- a/scripts/authenticate_docker.sh
+++ b/scripts/authenticate_docker.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
-set -eu pipefail
+set -eo pipefail
 
-docker login --username ${DOCKER_USERNAME} --password ${DOCKER_PASSWORD}
+if [[ -n "${DOCKER_USERNAME}" && -n "${DOCKER_PASSWORD}" ]]; then
+  docker login --username ${DOCKER_USERNAME} --password ${DOCKER_PASSWORD}
+fi


### PR DESCRIPTION
Authentication is only required to get around rate limiting.
This is more of an issue on build pipelines that on individual developer machines.

Don't force authentication but allow it to be run manually if rate
limits are encountered.