### PR TITLE
Fix validation error with rules and "contains" syntax

### DIFF
--- a/app/lib/use_cases/validate_radius_attributes.rb
+++ b/app/lib/use_cases/validate_radius_attributes.rb
@@ -24,6 +24,8 @@ module UseCases
           @errors.add(:base, "Error on row #{i + 2}: #{message}")
         end
       end
+    ensure
+      clean_up_tmp_config_files(config_file_path)
     end
   end
 end

--- a/spec/use_cases/validate_radius_attribute_spec.rb
+++ b/spec/use_cases/validate_radius_attribute_spec.rb
@@ -14,19 +14,27 @@ describe UseCases::ValidateRadiusAttribute do
       { key: "Alc-Ipv6-Secondary-Dns", value: "2001:0db8:85a3:0000:0000:8a2e:0370:7334" },
       { key: "Lucent-User-Acct-Expiration", value: 1_636_106_724 },
       { key: "Acct-Input-Octets-64", value: 123 },
-      { key: "IPv6-6rd-Configuration", value: 93_293 },
     ]
   end
 
   let(:invalid_attributes) do
     [
-      { key: "Invalid-Key", value: "whatever", expected_message: "Unknown name \"Invalid-Key\"" },
+      { key: "Invalid-Key", value: "whatever", expected_message: "Unknown attribute 'Invalid-Key'" },
       { key: "Aruba-User-Vlan", value: "not integer", expected_message: "Unknown or invalid value \"not integer\" for attribute Aruba-User-Vlan" },
       { key: "Aruba-AirGroup-Device-Type", value: %w[unsupported-item], expected_message: "Unknown or invalid value \"unsupported-item\" for attribute Aruba-AirGroup-Device-Type" },
       { key: "Aruba-AP-IP-Address", value: "not an ip", expected_message: "Failed resolving \"not an ip\" to IPv4 address: Name does not resolve" },
       { key: "Alc-Ipv6-Secondary-Dns", value: "not an ipv6 address", expected_message: "Failed resolving \"not an ipv6 address\" to IPv6 address: Name does not resolve" },
       { key: "Lucent-User-Acct-Expiration", value: "Not a unix timestamp", expected_message: "failed to parse time string \"Not a unix timestamp\"" },
       { key: "Acct-Input-Octets-64", value: "Not an integer64", expected_message: "Failed parsing \"Not an integer64\" as unsigned 64bit integer" },
+      { key: "IPv6-6rd-Configuration", value: 93_293, expected_message: "Cannot parse TLV" },
+    ]
+  end
+
+  let(:valid_rule_match_attributes) do
+    [
+      { key: "Tunnel-Type", value: "VLA", operator: "contains" },
+      { key: "Tunnel-Medium-Type", value: "IEEE", operator: "contains" },
+      { key: "Aruba-AirGroup-Device-Type", value: "Personal", operator: "contains" },
     ]
   end
 
@@ -38,20 +46,25 @@ describe UseCases::ValidateRadiusAttribute do
     assert_attributes(invalid_attributes, false)
   end
 
+  it "Allows using 'contains' syntax with partial strings" do
+    assert_attributes(valid_rule_match_attributes, true)
+  end
+
 private
 
   def assert_attributes(attributes, success)
     attributes.each do |attribute|
       value = attribute.fetch(:value)
       message = attribute.fetch(:expected_message, "")
+      operator = attribute.fetch(:operator, "")
 
       if value.is_a?(Array)
         value.each do |list_value|
-          result = subject.call(attribute: attribute.fetch(:key), value: list_value)
+          result = subject.call(attribute: attribute.fetch(:key), value: list_value, operator: operator)
           expect(result).to eq({ success: success, message: message })
         end
       else
-        result = subject.call(attribute: attribute.fetch(:key), value: value)
+        result = subject.call(attribute: attribute.fetch(:key), value: value, operator: operator)
         expect(result).to eq({ success: success, message: message })
       end
     end


### PR DESCRIPTION
Currently the FreeRadius validations block rules with substrings and a
contains operator eg.

Separate response validation from rule validation. To do this, write the
test configuration to /etc/raddb/sites-enabled/default. This is the only
file that supports both rules and response validations.