### PR TITLE
Add audit log for MAB imports

### DIFF
--- a/app/controllers/mac_authentication_bypasses_imports_controller.rb
+++ b/app/controllers/mac_authentication_bypasses_imports_controller.rb
@@ -1,6 +1,6 @@
 class MacAuthenticationBypassesImportsController < ApplicationController
   def new
-    @mac_authentication_bypasses_import = CSVImport::MacAuthenticationBypasses.new
+    @mac_authentication_bypasses_import = CSVImport::MacAuthenticationBypasses.new(current_user)
 
     authorize! :create, @mac_authentication_bypasses_import
   end
@@ -8,7 +8,7 @@ class MacAuthenticationBypassesImportsController < ApplicationController
   def create
     contents = mac_authentication_bypasses_import_params&.dig(:bypasses)&.read
 
-    @mac_authentication_bypasses_import = CSVImport::MacAuthenticationBypasses.new(contents)
+    @mac_authentication_bypasses_import = CSVImport::MacAuthenticationBypasses.new(current_user, contents)
 
     if @mac_authentication_bypasses_import.save
       publish_authorised_macs

--- a/app/controllers/mac_authentication_bypasses_imports_controller.rb
+++ b/app/controllers/mac_authentication_bypasses_imports_controller.rb
@@ -1,6 +1,8 @@
 class MacAuthenticationBypassesImportsController < ApplicationController
   def new
-    @mac_authentication_bypasses_import = CSVImport::MacAuthenticationBypasses.new(current_user)
+    @mac_authentication_bypasses_import = CSVImport::MacAuthenticationBypasses.new(
+      UseCases::AuditMacAuthenticationBypassesImport.new(current_user),
+    )
 
     authorize! :create, @mac_authentication_bypasses_import
   end

--- a/app/controllers/mac_authentication_bypasses_imports_controller.rb
+++ b/app/controllers/mac_authentication_bypasses_imports_controller.rb
@@ -8,7 +8,10 @@ class MacAuthenticationBypassesImportsController < ApplicationController
   def create
     contents = mac_authentication_bypasses_import_params&.dig(:bypasses)&.read
 
-    @mac_authentication_bypasses_import = CSVImport::MacAuthenticationBypasses.new(current_user, contents)
+    @mac_authentication_bypasses_import = CSVImport::MacAuthenticationBypasses.new(
+      UseCases::AuditMacAuthenticationBypassesImport.new(current_user),
+      contents,
+    )
 
     if @mac_authentication_bypasses_import.save
       publish_authorised_macs

--- a/app/lib/use_cases/audit_mac_authentication_bypasses_import.rb
+++ b/app/lib/use_cases/audit_mac_authentication_bypasses_import.rb
@@ -1,0 +1,38 @@
+class UseCases::AuditMacAuthenticationBypassesImport
+  def initialize(current_user)
+    @current_user = current_user
+  end
+
+  def call(records)
+    audits_to_save = []
+    audit_id = (Audit.last&.id || 0) + 1
+
+    records.each do |record|
+      mac_authentication_bypass = { address: record.address, name: record.name, description: record.description, site_id: record.site_id }
+
+      audits_to_save << {
+        auditable_id: audit_id,
+        action: "create",
+        audited_changes: mac_authentication_bypass,
+        auditable_type: "MacAuthenticationBypass",
+        user_id: @current_user.id,
+        user_type: "User",
+      }
+
+      record.responses.each do |response|
+        mab_response = { mac_authentication_bypass_id: record.id, response_attribute: response.response_attribute, value: response.value }
+
+        audits_to_save << {
+          auditable_id: audit_id,
+          action: "create",
+          audited_changes: mab_response,
+          auditable_type: "Response",
+          user_id: @current_user.id,
+          user_type: "User",
+        }
+      end
+    end
+
+    Audit.insert_all(audits_to_save)
+  end
+end

--- a/spec/acceptance/mac_authentication_bypass/bulk_upload_mab_spec.rb
+++ b/spec/acceptance/mac_authentication_bypass/bulk_upload_mab_spec.rb
@@ -87,6 +87,9 @@ describe "bulk upload MAC Authentication Bypasses", type: :feature do
       expect(page).to have_content("Hello to you")
       expect(page).to have_content("SG-Tunnel-Id")
       expect(page).to have_content("999")
+
+      expect_audit_log_entry_for(editor.email, "create", "Mac authentication bypass")
+      expect_audit_log_entry_for(editor.email, "create", "Response")
     end
 
     it "shows errors when the CSV is invalid" do

--- a/spec/use_cases/audit_mac_authentication_bypasses_import_spec.rb
+++ b/spec/use_cases/audit_mac_authentication_bypasses_import_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+
+describe UseCases::AuditMacAuthenticationBypassesImport do
+  subject(:use_case) do
+    described_class.new(user)
+  end
+
+  describe "#call" do
+    let!(:user) { build_stubbed(:user) }
+
+    context "when there are imported records" do
+      let!(:first_mab) { create(:mac_authentication_bypass, address: "aa-bb-cc-dd-ee-ff") }
+      let!(:second_mab) { create(:mac_authentication_bypass, address: "bb-bb-cc-dd-ee-ff") }
+      let!(:first_mab_response) { create(:mab_response, mac_authentication_bypass: first_mab, response_attribute: "Tunnel-Type", value: "VLAN") }
+      let!(:second_mab_response) { create(:mab_response, mac_authentication_bypass: first_mab, response_attribute: "Reply-Message", value: "Hello") }
+
+      it "audits the imported MABs" do
+        expect(use_case.call([first_mab, second_mab])).to be_truthy
+
+        first_audited_mab = Audit.all[-4]
+        first_audited_mab_response = Audit.all[-3]
+        second_audited_mab_response = Audit.all[-2]
+        second_audited_mab = Audit.last
+
+        expect(first_audited_mab.auditable_type).to eq("MacAuthenticationBypass")
+        expect(first_audited_mab.audited_changes).to eq({
+          "address" => first_mab.address,
+          "description" => first_mab.description,
+          "name" => first_mab.name,
+          "site_id" => first_mab.site_id,
+        })
+
+        expect(second_audited_mab.auditable_type).to eq("MacAuthenticationBypass")
+        expect(second_audited_mab.audited_changes).to eq({
+          "address" => second_mab.address,
+          "description" => second_mab.description,
+          "name" => second_mab.name,
+          "site_id" => second_mab.site_id,
+        })
+
+        expect(first_audited_mab_response.auditable_type).to eq("Response")
+        expect(first_audited_mab_response.audited_changes).to eq({
+          "mac_authentication_bypass_id" => first_mab.id,
+          "response_attribute" => first_mab_response.response_attribute,
+          "value" => first_mab_response.value,
+        })
+        expect(second_audited_mab_response.auditable_type).to eq("Response")
+        expect(second_audited_mab_response.audited_changes).to eq({
+          "mac_authentication_bypass_id" => first_mab.id,
+          "response_attribute" => second_mab_response.response_attribute,
+          "value" => second_mab_response.value,
+        })
+      end
+    end
+  end
+end

--- a/spec/use_cases/validate_radius_attributes_spec.rb
+++ b/spec/use_cases/validate_radius_attributes_spec.rb
@@ -6,7 +6,7 @@ describe UseCases::ValidateRadiusAttributes do
   end
 
   let(:errors) do
-    CSVImport::MacAuthenticationBypasses.new.errors
+    CSVImport::MacAuthenticationBypasses.new(build(:user)).errors
   end
 
   let(:invalid_response) do

--- a/spec/use_cases/validate_radius_attributes_spec.rb
+++ b/spec/use_cases/validate_radius_attributes_spec.rb
@@ -6,7 +6,7 @@ describe UseCases::ValidateRadiusAttributes do
   end
 
   let(:errors) do
-    CSVImport::MacAuthenticationBypasses.new(build(:user)).errors
+    CSVImport::MacAuthenticationBypasses.new(double(UseCases::AuditMacAuthenticationBypassesImport)).errors
   end
 
   let(:invalid_response) do


### PR DESCRIPTION
## Context

- Add audit log trail for MAB imports
  - invidiually logged for MAC authentication bypasses and responses 