### PR TITLE
Bulk upload sites clients validations

### DIFF
--- a/app/helpers/application_record_helper.rb
+++ b/app/helpers/application_record_helper.rb
@@ -9,7 +9,7 @@ module ApplicationRecordHelper
     result = UseCases::ValidateRadiusAttribute.new.call(attribute: attribute, value: value, operator: operator)
 
     unless result.fetch(:success)
-      errors.add(attribute.to_sym, result.fetch(:message))
+      errors.add(:base, result.fetch(:message))
     end
   end
 end

--- a/app/lib/use_cases/CSV_import/client.rb
+++ b/app/lib/use_cases/CSV_import/client.rb
@@ -1,0 +1,9 @@
+module UseCases
+  module CSVImport
+    class Client < Client
+      def skip_validation?
+        true
+      end
+    end
+  end
+end

--- a/app/lib/use_cases/CSV_import/parse_sites_with_clients.rb
+++ b/app/lib/use_cases/CSV_import/parse_sites_with_clients.rb
@@ -76,13 +76,13 @@ module UseCases
     def map_clients(eap_clients, radsec_clients, record, last_client_id)
       if eap_clients
         eap_clients.split(";").each.with_index(1) do |eap_client, eap_client_index|
-          record.clients << Client.new(id: last_client_id + eap_client_index, ip_range: eap_client, radsec: false)
+          record.clients << CSVImport::Client.new(id: last_client_id + eap_client_index, ip_range: eap_client, radsec: false)
         end
       end
 
       if radsec_clients
         radsec_clients.split(";").each.with_index(1) do |radsec_client, radsec_client_index|
-          record.clients << Client.new(id: record.clients.last.id + radsec_client_index, ip_range: radsec_client, radsec: true)
+          record.clients << CSVImport::Client.new(id: record.clients.last.id + radsec_client_index, ip_range: radsec_client, radsec: true)
         end
       end
     end

--- a/app/lib/use_cases/CSV_import/parse_sites_with_clients.rb
+++ b/app/lib/use_cases/CSV_import/parse_sites_with_clients.rb
@@ -77,7 +77,7 @@ module UseCases
     def unwrap_responses(fallback_policy_responses)
       fallback_policy_responses.to_s.split(";").map do |r|
         response_attribute, value = r.split("=")
-        PolicyResponse.new(response_attribute: response_attribute, value: value)
+        Response.new(response_attribute: response_attribute, value: value)
       end
     end
 

--- a/app/lib/use_cases/CSV_import/parse_sites_with_clients.rb
+++ b/app/lib/use_cases/CSV_import/parse_sites_with_clients.rb
@@ -1,6 +1,5 @@
 module UseCases
   require "csv"
-
   class CSVImport::ParseSitesWithClients
     CSV_HEADERS = "Site Name,EAP Clients,RadSec Clients,Policies,Fallback Policy".freeze
 
@@ -27,7 +26,7 @@ module UseCases
         policies = row["Policies"]
         fallback_policy = row["Fallback Policy"]
 
-        record = Site.new(
+        record = CSVImport::Site.new(
           id: last_site_id + i,
           name: site_name,
         )

--- a/app/lib/use_cases/CSV_import/site.rb
+++ b/app/lib/use_cases/CSV_import/site.rb
@@ -1,0 +1,9 @@
+module UseCases
+  module CSVImport
+    class Site < Site
+      def skip_uniqueness_validation?
+        true
+      end
+    end
+  end
+end

--- a/app/lib/use_cases/validate_radius_attribute.rb
+++ b/app/lib/use_cases/validate_radius_attribute.rb
@@ -5,8 +5,12 @@ module UseCases
     DEFAULT_SITE_PATH = "/etc/raddb/sites-enabled/default".freeze
 
     def call(attribute:, value:, operator: nil)
+      clean_up_tmp_config_files(DEFAULT_SITE_PATH)
+
       write_tmp_config_file(DEFAULT_SITE_PATH, test_config(attribute, value, operator))
       payload(error_from_logs(boot_freeradius_to_validate_attributes), attribute, value)
+    ensure
+      clean_up_tmp_config_files(DEFAULT_SITE_PATH)
     end
 
   private

--- a/app/models/CSV_import/sites_with_clients.rb
+++ b/app/models/CSV_import/sites_with_clients.rb
@@ -79,14 +79,9 @@ module CSVImport
       @records.each.with_index(2) do |record, row|
         record.validate
 
-        if site_names.detect { |site_name| site_name == record.name }
-          errors.add(:base, "Error on row #{row}: Site Name has already been taken")
-        else
-          site_names << record.name
-        end
-
-        validate_uniqueness_of_ip_ranges(record.clients.reject(&:radsec), eap_ip_ranges, row)
-        validate_uniqueness_of_ip_ranges(record.clients.select(&:radsec), radsec_ip_ranges, row)
+        validate_uniqueness_of_site_name(record.name, site_names, row)
+        validate_ip_ranges(record.clients.reject(&:radsec), eap_ip_ranges, row)
+        validate_ip_ranges(record.clients.select(&:radsec), radsec_ip_ranges, row)
 
         record.errors.full_messages.each do |error|
           errors.add(:base, "Error on row #{row}: Site #{error}")
@@ -112,7 +107,7 @@ module CSVImport
       end
     end
 
-    def validate_uniqueness_of_ip_ranges(clients, ip_ranges, row)
+    def validate_ip_ranges(clients, ip_ranges, row)
       clients.each do |client|
         if ip_ranges.include?(client.ip_range)
           return errors.add(:base, "Error on row #{row}: Client Ip range has already been taken")
@@ -132,6 +127,14 @@ module CSVImport
       end
 
       false
+    end
+
+    def validate_uniqueness_of_site_name(site_name, existing_site_names, row)
+      if existing_site_names.include?(site_name)
+        errors.add(:base, "Error on row #{row}: Site Name has already been taken")
+      else
+        existing_site_names << site_name
+      end
     end
   end
 end

--- a/app/models/CSV_import/sites_with_clients.rb
+++ b/app/models/CSV_import/sites_with_clients.rb
@@ -72,16 +72,24 @@ module CSVImport
     def validate_records
       return unless @records
 
+      site_names = Site.pluck(:name)
+
       @records.each.with_index(2) do |record, row|
         record.validate
 
+        if site_names.detect { |site_name| site_name == record.name }
+          errors.add(:base, "Error on row #{row}: Site Name has already been taken")
+        else
+          site_names << record.name
+        end
+
         record.errors.full_messages.each do |error|
-          errors.add(:base, "Error on row #{row}: #{record.class} #{error}")
+          errors.add(:base, "Error on row #{row}: Site #{error}")
         end
 
         record.clients.each do |client|
           client.errors.full_messages.each do |client_error|
-            errors.add(:base, "Error on row #{row}: #{client.class} #{client_error}")
+            errors.add(:base, "Error on row #{row}: Client #{client_error}")
           end
         end
 

--- a/app/models/CSV_import/sites_with_clients.rb
+++ b/app/models/CSV_import/sites_with_clients.rb
@@ -79,15 +79,21 @@ module CSVImport
           errors.add(:base, "Error on row #{row}: #{record.class} #{error}")
         end
 
-        record.policies.each do |policy|
-          policy.errors.full_messages.each do |policy_error|
-            errors.add(:base, "Error on row #{row}: #{policy.class} #{policy_error}")
-          end
-        end
-
         record.clients.each do |client|
           client.errors.full_messages.each do |client_error|
             errors.add(:base, "Error on row #{row}: #{client.class} #{client_error}")
+          end
+        end
+
+        fallback_policy = record.policies.first
+
+        fallback_policy.errors.full_messages.each do |fallback_policy_error|
+          errors.add(:base, "Error on row #{row}: Fallback Policy #{fallback_policy_error}")
+        end
+
+        fallback_policy.responses.each do |response|
+          response.errors.full_messages.each do |response_error|
+            errors.add(:base, "Error on row #{row}: #{response_error}")
           end
         end
       end

--- a/app/models/CSV_import/sites_with_clients.rb
+++ b/app/models/CSV_import/sites_with_clients.rb
@@ -84,6 +84,12 @@ module CSVImport
             errors.add(:base, "Error on row #{row}: #{policy.class} #{policy_error}")
           end
         end
+
+        record.clients.each do |client|
+          client.errors.full_messages.each do |client_error|
+            errors.add(:base, "Error on row #{row}: #{client.class} #{client_error}")
+          end
+        end
       end
     end
   end

--- a/app/models/CSV_import/sites_with_clients.rb
+++ b/app/models/CSV_import/sites_with_clients.rb
@@ -5,6 +5,7 @@ module CSVImport
     attr_accessor :records
 
     validate :validate_csv_format
+    validate :validate_records
 
     def initialize(parse_csv)
       parsed_records = parse_csv.call
@@ -65,6 +66,24 @@ module CSVImport
 
       @csv_parse_errors.each do |error|
         errors.add(:base, error)
+      end
+    end
+
+    def validate_records
+      return unless @records
+
+      @records.each.with_index(2) do |record, row|
+        record.validate
+
+        record.errors.full_messages.each do |error|
+          errors.add(:base, "Error on row #{row}: #{record.class} #{error}")
+        end
+
+        record.policies.each do |policy|
+          policy.errors.full_messages.each do |policy_error|
+            errors.add(:base, "Error on row #{row}: #{policy.class} #{policy_error}")
+          end
+        end
       end
     end
   end

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -8,8 +8,8 @@ class Client < ApplicationRecord
 
   validates_presence_of :ip_range, :shared_secret
   validate :validate_ip
-  validates :ip_range, presence: true, uniqueness: { scope: :radsec }
-  validate :validate_ip_range_overlap, on: %i[create update]
+  validates :ip_range, presence: true, uniqueness: { scope: :radsec }, unless: :skip_validation?
+  validate :validate_ip_range_overlap, on: %i[create update], unless: :skip_validation?
 
 private
 
@@ -39,6 +39,10 @@ private
     return if shared_secret.present?
 
     self.shared_secret = radsec? ? RADSEC_SHARED_SECRET : SecureRandom.hex(SHARED_SECRET_BYTES).upcase
+  end
+
+  def skip_validation?
+    false
   end
 
   audited

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -1,7 +1,8 @@
 class Site < ApplicationRecord
   paginates_per 50
 
-  validates :name, presence: true, uniqueness: { case_sensitive: false }
+  validates :name, presence: true
+  validates :name, uniqueness: { case_sensitive: false }, unless: :skip_uniqueness_validation?
 
   has_many :clients, dependent: :destroy
   has_many :mac_authentication_bypasses, dependent: :nullify
@@ -36,5 +37,9 @@ private
       errors.add :name, "Failed to generate fallback policy with error: #{fallback_policy.errors.full_messages.join(', ')}"
       raise ActiveRecord::RecordInvalid
     end
+  end
+
+  def skip_uniqueness_validation?
+    false
   end
 end

--- a/spec/models/CSV_import/sites_with_clients_spec.rb
+++ b/spec/models/CSV_import/sites_with_clients_spec.rb
@@ -86,6 +86,25 @@ Petty France,128.0.0.1;10.0.0.1/32,128.0.0.1,Test Policy 1,Dlink-VLAN-ID=888;Rep
     end
   end
 
+  context "when there are duplicate site records" do
+    let(:file_contents) do
+      "Site Name,EAP Clients,RadSec Clients,Policies,Fallback Policy
+Petty France,,,,
+Petty France,,,,"
+    end
+
+    let(:parse_sites_with_clients) { UseCases::CSVImport::ParseSitesWithClients.new(file_contents) }
+
+    it "show a validation error" do
+      expect(subject).to_not be_valid
+      expect(subject.errors.full_messages).to eq(
+        [
+          "Error on row 3: Site Name has already been taken",
+        ],
+      )
+    end
+  end
+
   context "when a client ip range has already been taken" do
     let(:file_contents) do
       "Site Name,EAP Clients,RadSec Clients,Policies,Fallback Policy

--- a/spec/models/CSV_import/sites_with_clients_spec.rb
+++ b/spec/models/CSV_import/sites_with_clients_spec.rb
@@ -60,4 +60,29 @@ Petty France,128.0.0.1;10.0.0.1/32,128.0.0.1,Test Policy 1;Test Policy 2,Dlink-V
       )
     end
   end
+
+  context "when a site already exists" do
+    let(:file_contents) do
+      "Site Name,EAP Clients,RadSec Clients,Policies,Fallback Policy
+Petty France,128.0.0.1;10.0.0.1/32,128.0.0.1,Test Policy 1,Dlink-VLAN-ID=888;Reply-Message=hi"
+    end
+
+    let(:parse_sites_with_clients) { UseCases::CSVImport::ParseSitesWithClients.new(file_contents) }
+
+    before do
+      create(:site, name: "Petty France")
+      create(:policy, name: "Test Policy 1")
+    end
+
+    it "show a validation error" do
+      expect(subject).to_not be_valid
+      expect(subject.errors.full_messages).to eq(
+        [
+          "Error on row 2: Site Name has already been taken",
+          "Error on row 2: Site Policies is invalid",
+          "Error on row 2: Policy Name has already been taken",
+        ],
+      )
+    end
+  end
 end

--- a/spec/models/CSV_import/sites_with_clients_spec.rb
+++ b/spec/models/CSV_import/sites_with_clients_spec.rb
@@ -80,7 +80,7 @@ Petty France,128.0.0.1;10.0.0.1/32,128.0.0.1,Test Policy 1,Dlink-VLAN-ID=888;Rep
         [
           "Error on row 2: Site Name has already been taken",
           "Error on row 2: Site Policies is invalid",
-          "Error on row 2: Policy Name has already been taken",
+          "Error on row 2: Fallback Policy Name has already been taken",
         ],
       )
     end
@@ -129,6 +129,26 @@ Petty France,128.0.0.1;10.0.0.1/32,128.0.0.1,Test Policy 1,Dlink-VLAN-ID=888;Rep
         [
           "Error on row 2: Site Clients is invalid",
           "Error on row 2: Client Ip range IP overlaps with Some Site Name - 128.0.0.1/16",
+        ],
+      )
+    end
+  end
+
+  context "when a fallback policy response is invalid" do
+    let(:file_contents) do
+      "Site Name,EAP Clients,RadSec Clients,Policies,Fallback Policy
+  Petty France,,,,Invalid-Attribute=888"
+    end
+
+    let(:parse_sites_with_clients) { UseCases::CSVImport::ParseSitesWithClients.new(file_contents) }
+
+    it "show a validation error" do
+      expect(subject).to_not be_valid
+      expect(subject.errors.full_messages).to eq(
+        [
+          "Error on row 2: Site Policies is invalid",
+          "Error on row 2: Fallback Policy Responses is invalid",
+          "Error on row 2: Unknown attribute 'Invalid-Attribute'",
         ],
       )
     end

--- a/spec/use_cases/CSV_import/parse_sites_with_clients_spec.rb
+++ b/spec/use_cases/CSV_import/parse_sites_with_clients_spec.rb
@@ -61,7 +61,7 @@ Petty France,128.0.0.1;10.0.0.1/32,128.0.0.1,Test Policy 1;Test Policy 2,Dlink-V
     context "when optional data is not provided" do
       let(:file_contents) do
         "Site Name,EAP Clients,RadSec Clients,Policies,Fallback Policy
-Petty France,,,"
+Petty France,,,,"
       end
 
       let(:parse_sites_with_clients) { UseCases::CSVImport::ParseSitesWithClients.new(file_contents) }

--- a/spec/use_cases/CSV_import/parse_sites_with_clients_spec.rb
+++ b/spec/use_cases/CSV_import/parse_sites_with_clients_spec.rb
@@ -58,6 +58,22 @@ Petty France,128.0.0.1;10.0.0.1/32,128.0.0.1,Test Policy 1;Test Policy 2,Dlink-V
       end
     end
 
+    context "when optional data is not provided" do
+      let(:file_contents) do
+        "Site Name,EAP Clients,RadSec Clients,Policies,Fallback Policy
+Petty France,,,"
+      end
+
+      let(:parse_sites_with_clients) { UseCases::CSVImport::ParseSitesWithClients.new(file_contents) }
+      let(:records) { subject.call[:records] }
+
+      it "creates a valid site with a fallback policy" do
+        expect(subject.call[:errors]).to be_empty
+        expect(records.first.name).to eq("Petty France")
+        expect(records.first.policies.first.name).to eq("Fallback policy for Petty France")
+      end
+    end
+
     context "when the CSV header is invalid" do
       let(:file_contents) do
         "Site NameInvalid


### PR DESCRIPTION
## Context
This change is to allow network engineers to bulk upload sites and clients data. This is the second slice of implementing the functionality, covers the validations for the `CSVImport::SiteWithClients` model

### Changes
- Implement validations for `CSVImport::SiteWithClients`
- Validate Sites data
- Validate Clients data
- Validate Fallback policies attributes

### Next steps:
- Add acceptance tests
- Add uploading sites to the `Sites` view
- Performance improvements