### PR TITLE
Allow bulk uploading sites and clients

### DIFF
--- a/app/controllers/sites_import_controller.rb
+++ b/app/controllers/sites_import_controller.rb
@@ -1,0 +1,31 @@
+class SitesImportController < ApplicationController
+  def new
+    @sites_with_clients_import = CSVImport::SitesWithClients.new(
+      UseCases::CSVImport::ParseSitesWithClients.new(""),
+    )
+
+    authorize! :create, @sites_with_clients_import
+  end
+
+  def create
+    contents = sites_import_params&.dig(:sites_with_clients)&.read
+
+    @sites_with_clients_import = CSVImport::SitesWithClients.new(
+      UseCases::CSVImport::ParseSitesWithClients.new(contents),
+    )
+
+    if @sites_with_clients_import.save
+      redirect_to mac_authentication_bypasses_path, notice: "Successfully imported sites with clients"
+    else
+      render :new
+    end
+  end
+
+private
+
+  def sites_import_params
+    return if params[:csv_import_sites_with_clients].nil?
+
+    params.require(:csv_import_sites_with_clients).permit(:sites_with_clients)
+  end
+end

--- a/app/controllers/sites_import_controller.rb
+++ b/app/controllers/sites_import_controller.rb
@@ -15,7 +15,8 @@ class SitesImportController < ApplicationController
     )
 
     if @sites_with_clients_import.save
-      redirect_to mac_authentication_bypasses_path, notice: "Successfully imported sites with clients"
+      deploy_service
+      redirect_to sites_path, notice: "Successfully imported sites with clients"
     else
       render :new
     end

--- a/app/lib/use_cases/CSV_import/parse_sites_with_clients.rb
+++ b/app/lib/use_cases/CSV_import/parse_sites_with_clients.rb
@@ -95,9 +95,9 @@ module UseCases
     end
 
     def remove_utf8_byte_order_mark(content)
-      return content[3..] if "\xEF\xBB\xBFA".force_encoding("ASCII-8BIT") == content[0..3]
+      return content[3..].force_encoding("UTF-8") if content[0..3].include?("\xEF\xBB\xBF".force_encoding("ASCII-8BIT"))
 
-      content
+      content.force_encoding("UTF-8")
     end
 
     def validate_csv

--- a/app/models/CSV_import/sites_with_clients.rb
+++ b/app/models/CSV_import/sites_with_clients.rb
@@ -55,7 +55,7 @@ module CSVImport
         Site.insert_all(sites_to_save)
         Client.insert_all(clients_to_save) if clients_to_save.any?
         Policy.insert_all(fallback_policies_to_save)
-        PolicyResponse.insert_all(fallback_policy_responses_to_save)
+        PolicyResponse.insert_all(fallback_policy_responses_to_save) if fallback_policy_responses_to_save.any?
         SitePolicy.insert_all(site_policies_to_save)
       end
     end

--- a/app/models/CSV_import/sites_with_clients.rb
+++ b/app/models/CSV_import/sites_with_clients.rb
@@ -34,6 +34,7 @@ module CSVImport
         site.policies.each do |policy|
           if policy.fallback?
             fallback_policies_to_save << {
+              id: policy.id,
               name: policy.name,
               description: policy.description,
               fallback: policy.fallback,
@@ -52,7 +53,7 @@ module CSVImport
 
       ActiveRecord::Base.transaction do
         Site.insert_all(sites_to_save)
-        Client.insert_all(clients_to_save)
+        Client.insert_all(clients_to_save) if clients_to_save.any?
         Policy.insert_all(fallback_policies_to_save)
         PolicyResponse.insert_all(fallback_policy_responses_to_save)
         SitePolicy.insert_all(site_policies_to_save)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -2,8 +2,30 @@ class Ability
   include CanCan::Ability
 
   def initialize(user)
-    can :read, [Policy, Site, Rule, Response, Certificate, MacAuthenticationBypass, CSVImport::MacAuthenticationBypasses, Client]
+    can :read, [
+      Policy,
+      Site,
+      Rule,
+      Response,
+      Certificate,
+      MacAuthenticationBypass,
+      CSVImport::MacAuthenticationBypasses,
+      CSVImport::SitesWithClients,
+      Client,
+    ]
 
-    can :manage, [Policy, Site, Rule, Response, Certificate, MacAuthenticationBypass, CSVImport::MacAuthenticationBypasses, Client] if user.editor?
+    if user.editor?
+      can :manage, [
+        Policy,
+        Site,
+        Rule,
+        Response,
+        Certificate,
+        MacAuthenticationBypass,
+        CSVImport::MacAuthenticationBypasses,
+        CSVImport::SitesWithClients,
+        Client,
+      ]
+    end
   end
 end

--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -7,6 +7,7 @@
           <h4 class="govuk-heading-m">For policy: <%= link_to @policy.name, policy_path(@policy), class: "govuk-link" %>
         <% elsif can? :create, Site %>
           <%= link_to "Create a new site", new_site_path, class: "govuk-button" %>
+          <%= link_to "Import sites with clients", new_sites_import_path, class: "govuk-button"%>
         <% end %>
       </th>
       <th scope="col" class="govuk-table__header search_bar">

--- a/app/views/sites_import/new.html.erb
+++ b/app/views/sites_import/new.html.erb
@@ -1,0 +1,29 @@
+<%= render "layouts/form_errors", resource: @sites_with_clients_import %>
+
+<%= form_with model: @sites_with_clients_import, local: true, url: sites_import_index_path do |f| %>
+  <h2 class="govuk-heading-l">Import sites with clients</h2>
+
+  <div class="govuk-form-group">
+    <div id="csv-hint" class="govuk-hint">
+      Header must contain the following: "<%= UseCases::CSVImport::ParseSitesWithClients::CSV_HEADERS %>".<br /><br />
+      Clients must be separated by a semicolon.<br />
+      For example: 127.0.0.1/32;128.0.0.1/32<br /><br />
+      Fallback Policy Responses must be separated by a semicolon.<br />
+      For example: Tunnel-Type=VLAN;Reply-Message=Welcome;SG-Tunnel-Id=333<br /><br />
+      File must be a valid CSV with UTF-8 encoding.<br />
+    </div>
+    <%= f.file_field :sites_with_clients, id: :csv_file, class: "govuk-file-upload" %>
+  </div>
+
+  <%= f.submit "Upload", {
+    class: "govuk-button",
+    "data-module" => "govuk-button"
+  } %>
+
+  <%= link_to "Cancel", sites_path,
+    class: "govuk-button govuk-button--secondary",
+    data: {
+      module: "govuk-button"
+    }
+  %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,8 @@ Rails.application.routes.draw do
     resources :clients, except: %i[index show]
   end
 
+  resources :sites_import
+
   get "/sites/:id/policies", to: "sites#site_policies", as: "site_policies"
   post "/sites/:id/policies", to: "sites#attach_site_policies", as: "attach_site_policies"
   get "/sites/:id/policies/edit", to: "sites#edit_site_policies", as: "edit_site_policies"

--- a/spec/acceptance/sites/bulk_upload_sites_with_clients_spec.rb
+++ b/spec/acceptance/sites/bulk_upload_sites_with_clients_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+describe "bulk upload Sites with Clients", type: :feature do
+  context "when the user is unauthenticated" do
+    it "does not allow importing sites" do
+      visit "/sites_import/new"
+
+      expect(page).to have_content "You need to sign in or sign up before continuing."
+    end
+  end
+
+  context "when the user is a viewer" do
+    before do
+      login_as create(:user, :reader)
+    end
+
+    it "does not allow importing sites" do
+      visit "/sites"
+
+      expect(page).not_to have_content "Import sites with clients"
+
+      visit "/sites_import/new"
+
+      expect(page).to have_content "You are not authorized to access this page."
+    end
+  end
+
+  context "when the user is an editor" do
+    let(:editor) { create(:user, :editor) }
+
+    before do
+      login_as editor
+    end
+
+    it "shows errors when the CSV is missing" do
+      visit "/sites"
+
+      click_on "Import sites with clients"
+
+      expect(current_path).to eql("/sites_import/new")
+
+      click_on "Upload"
+
+      expect(page).to have_content("CSV is missing")
+    end
+  end
+end

--- a/spec/acceptance/sites/bulk_upload_sites_with_clients_spec.rb
+++ b/spec/acceptance/sites/bulk_upload_sites_with_clients_spec.rb
@@ -29,6 +29,9 @@ describe "bulk upload Sites with Clients", type: :feature do
     let(:editor) { create(:user, :editor) }
 
     before do
+      create(:policy, name: "Test Policy 1")
+      create(:policy, name: "Test Policy 2")
+
       login_as editor
     end
 
@@ -42,6 +45,79 @@ describe "bulk upload Sites with Clients", type: :feature do
       click_on "Upload"
 
       expect(page).to have_content("CSV is missing")
+    end
+
+    it "imports sites with clients from a valid CSV" do
+      expect_service_deployment
+
+      visit "/sites"
+
+      click_on "Import sites with clients"
+
+      expect(current_path).to eql("/sites_import/new")
+
+      attach_file("csv_file", "spec/fixtures/sites_csv/valid.csv")
+      click_on "Upload"
+
+      expect(current_path).to eql("/sites")
+      expect(page).to have_content("Successfully imported sites with clients")
+
+      expect(page).to have_content("Site 1")
+      expect(page).to have_content("Site 2")
+      expect(page).to have_content("Site 3")
+
+      visit "/sites/#{Site.first.id}"
+
+      expect(page).to have_content("127.1.1.1/32")
+      expect(page).to have_content("128.1.1.1/32")
+      expect(page).to have_content("Test Policy 1")
+
+      click_on "Fallback policy for Site 1"
+
+      expect(page).to have_content("Dlink-VLAN-ID")
+      expect(page).to have_content("888")
+      expect(page).to have_content("Reply-Message")
+      expect(page).to have_content("hi")
+
+      visit "/sites/#{Site.second.id}"
+
+      expect(page).to have_content("127.2.2.2/32")
+      expect(page).to have_content("128.2.2.2/32")
+      expect(page).to have_content("Test Policy 2")
+
+      click_on "Fallback policy for Site 2"
+
+      expect(page).to have_content("Dlink-VLAN-ID")
+      expect(page).to have_content("888")
+      expect(page).to have_content("Reply-Message")
+      expect(page).to have_content("hi")
+
+      visit "/sites/#{Site.third.id}"
+
+      expect(page).to have_content("126.3.3.3/32")
+      expect(page).to have_content("127.3.3.3/32")
+      expect(page).to have_content("128.4.4.4/32")
+      expect(page).to have_content("Test Policy 1")
+      expect(page).to have_content("Test Policy 2")
+      expect(page).to have_content("Fallback policy for Site 3")
+    end
+
+    it "can upload CRLF file format" do
+      visit "/sites_import/new"
+
+      attach_file("csv_file", "spec/fixtures/sites_csv/valid_crlf.csv")
+      click_on "Upload"
+
+      expect(page).to have_content("Successfully imported sites with clients")
+    end
+
+    it "can upload a UTF8_BOM file (Windows support)" do
+      visit "/sites_import/new"
+
+      attach_file("csv_file", "spec/fixtures/sites_csv/valid_utf8_bom.csv")
+      click_on "Upload"
+
+      expect(page).to have_content("Successfully imported sites with clients")
     end
   end
 end

--- a/spec/fixtures/sites_csv/valid.csv
+++ b/spec/fixtures/sites_csv/valid.csv
@@ -1,0 +1,4 @@
+Site Name,EAP Clients,RadSec Clients,Policies,Fallback Policy
+Site 1,127.1.1.1,128.1.1.1,Test Policy 1,Dlink-VLAN-ID=888;Reply-Message=hi
+Site 2,127.2.2.2,128.2.2.2,Test Policy 2,Dlink-VLAN-ID=888;Reply-Message=hi
+Site 3,126.3.3.3,127.3.3.3;128.4.4.4,Test Policy 1;Test Policy 2,

--- a/spec/fixtures/sites_csv/valid_crlf.csv
+++ b/spec/fixtures/sites_csv/valid_crlf.csv
@@ -1,0 +1,2 @@
+Site Name,EAP Clients,RadSec Clients,Policies,Fallback Policy
+Some Site,,,,,

--- a/spec/fixtures/sites_csv/valid_utf8_bom.csv
+++ b/spec/fixtures/sites_csv/valid_utf8_bom.csv
@@ -1,0 +1,2 @@
+﻿Site Name,EAP Clients,RadSec Clients,Policies,Fallback Policy
+Site 1,,,,,

--- a/spec/models/CSV_import/sites_with_clients_spec.rb
+++ b/spec/models/CSV_import/sites_with_clients_spec.rb
@@ -73,6 +73,33 @@ Petty France,,,,Dlink-VLAN-ID=888;Reply-Message=hi"
     end
   end
 
+  context "valid csv entries without fallback policy responses" do
+    let(:file_contents) do
+      "Site Name,EAP Clients,RadSec Clients,Policies,Fallback Policy
+Petty France,128.0.0.1,,,"
+    end
+
+    let(:parse_sites_with_clients) { UseCases::CSVImport::ParseSitesWithClients.new(file_contents) }
+
+    it "creates valid sites and fallback policies with no responses" do
+      expect(subject).to be_valid
+      expect(subject.errors).to be_empty
+      expect(subject.records.count).to be(1)
+
+      expect(subject.save).to be_truthy
+
+      saved_site = Site.last
+
+      expect(saved_site.id).to_not be_nil
+      expect(saved_site.tag).to eq("petty_france")
+      expect(saved_site.clients.count).to be(1)
+
+      expect(saved_site.policy_count).to eq(1)
+      expect(saved_site.fallback_policy.name).to eq("Fallback policy for Petty France")
+      expect(saved_site.fallback_policy.responses).to be_empty
+    end
+  end
+
   context "when CSV parser return errors" do
     let(:file_contents) { "INVALID" }
     let(:parse_sites_with_clients) { instance_double(UseCases::CSVImport::ParseSitesWithClients) }

--- a/spec/models/CSV_import/sites_with_clients_spec.rb
+++ b/spec/models/CSV_import/sites_with_clients_spec.rb
@@ -43,6 +43,36 @@ Petty France,128.0.0.1;10.0.0.1/32,128.0.0.1,Test Policy 1;Test Policy 2,Dlink-V
     end
   end
 
+  context "valid csv entries without clients or policies" do
+    let(:file_contents) do
+      "Site Name,EAP Clients,RadSec Clients,Policies,Fallback Policy
+Petty France,,,,Dlink-VLAN-ID=888;Reply-Message=hi"
+    end
+
+    let(:parse_sites_with_clients) { UseCases::CSVImport::ParseSitesWithClients.new(file_contents) }
+
+    it "creates valid sites and fallback policies" do
+      expect(subject).to be_valid
+      expect(subject.errors).to be_empty
+      expect(subject.records.count).to be(1)
+
+      expect(subject.save).to be_truthy
+
+      saved_site = Site.last
+
+      expect(saved_site.id).to_not be_nil
+      expect(saved_site.tag).to eq("petty_france")
+      expect(saved_site.clients).to be_empty
+
+      expect(saved_site.policy_count).to eq(1)
+      expect(saved_site.fallback_policy.name).to eq("Fallback policy for Petty France")
+      expect(saved_site.fallback_policy.responses.first.response_attribute).to eq("Dlink-VLAN-ID")
+      expect(saved_site.fallback_policy.responses.first.value).to eq("888")
+      expect(saved_site.fallback_policy.responses.second.response_attribute).to eq("Reply-Message")
+      expect(saved_site.fallback_policy.responses.second.value).to eq("hi")
+    end
+  end
+
   context "when CSV parser return errors" do
     let(:file_contents) { "INVALID" }
     let(:parse_sites_with_clients) { instance_double(UseCases::CSVImport::ParseSitesWithClients) }


### PR DESCRIPTION
## Context
This change is to allow network engineers to bulk upload sites and clients data. This is the third slice of implementing the functionality, covers adding CSV import capability to the Sites page

### Changes
- Add CSV import page for sites and clients
- Allow importing sites with no clients
- Allow importing sites without fallback policy responses
- Allow importing sites and clients when CSV is valid

### Next steps:
- Performance improvements
- Audit imports