### PR TITLE
Collect errors returned by CSV import

### DIFF
--- a/app/controllers/mac_authentication_bypasses_imports_controller.rb
+++ b/app/controllers/mac_authentication_bypasses_imports_controller.rb
@@ -8,9 +8,14 @@ class MacAuthenticationBypassesImportsController < ApplicationController
   def create
     contents = mac_authentication_bypasses_import_params.fetch(:file).read
 
-    MacAuthenticationBypassImportJob.perform_later(contents)
+    csv_import_result = CsvImportResult.create!
+    MacAuthenticationBypassImportJob.perform_later(contents, csv_import_result)
 
-    redirect_to mac_authentication_bypasses_path, notice: "Importing MAC addresses"
+    redirect_to mac_authentication_bypasses_import_path(csv_import_result), notice: "Importing MAC addresses"
+  end
+
+  def show
+    @csv_import_result = CsvImportResult.find(params.fetch(:id))
   end
 
 private

--- a/app/jobs/mac_authentication_bypass_import_job.rb
+++ b/app/jobs/mac_authentication_bypass_import_job.rb
@@ -1,9 +1,9 @@
 class MacAuthenticationBypassImportJob < ActiveJob::Base
-  def perform(contents)
+  def perform(contents, csv_import_result)
     result = UseCases::CSVImport::MacAuthenticationBypasses.new(contents).save
 
     if result.fetch(:errors).any?
-      abort(result.fetch(:errors).join("\n"))
+      csv_import_result.update_attributes(import_errors: errors)
     else
       publish_authorised_macs
       deploy_service

--- a/app/models/csv_import_result.rb
+++ b/app/models/csv_import_result.rb
@@ -1,0 +1,2 @@
+class CsvImportResult < ApplicationRecord
+end

--- a/db/migrate/20220202154503_create_csv_import_results.rb
+++ b/db/migrate/20220202154503_create_csv_import_results.rb
@@ -1,0 +1,8 @@
+class CreateCsvImportResults < ActiveRecord::Migration[7.0]
+  def change
+    create_table :csv_import_results do |t|
+      t.text :import_errors
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_31_144107) do
+ActiveRecord::Schema.define(version: 2022_02_02_154503) do
 
   create_table "audits", charset: "utf8", force: :cascade do |t|
     t.integer "auditable_id"
@@ -56,6 +56,12 @@ ActiveRecord::Schema.define(version: 2022_01_31_144107) do
     t.timestamp "updated_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.boolean "radsec", null: false
     t.index ["site_id"], name: "index_clients_on_site_id"
+  end
+
+  create_table "csv_import_results", charset: "utf8", force: :cascade do |t|
+    t.text "import_errors"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "delayed_jobs", charset: "utf8", force: :cascade do |t|

--- a/spec/acceptance/mac_authentication_bypass/import_spec.rb
+++ b/spec/acceptance/mac_authentication_bypass/import_spec.rb
@@ -52,7 +52,11 @@ describe "Import MAC Authentication Bypasses", type: :feature do
       Delayed::Worker.new.work_off
       expect(Delayed::Job.count).to eq(0)
 
-      expect(current_path).to eql("/mac_authentication_bypasses")
+      expect(CsvImportResult.all.count).to eq(1)
+      expect(CsvImportResult.first.errors).to be_empty
+
+      expect(page.current_path).to eq(mac_authentication_bypasses_import_path(CsvImportResult.last.id))
+
       expect(page).to have_content("Importing MAC addresses")
 
       visit "/mac_authentication_bypasses"
@@ -100,6 +104,7 @@ describe "Import MAC Authentication Bypasses", type: :feature do
       # revisit
       expect_audit_log_entry_for("System", "create", "Mac authentication bypass")
       expect_audit_log_entry_for("System", "create", "Response")
+
     end
 
     it "can upload CRLF file format" do

--- a/spec/acceptance/mac_authentication_bypass/import_spec.rb
+++ b/spec/acceptance/mac_authentication_bypass/import_spec.rb
@@ -104,7 +104,6 @@ describe "Import MAC Authentication Bypasses", type: :feature do
       # revisit
       expect_audit_log_entry_for("System", "create", "Mac authentication bypass")
       expect_audit_log_entry_for("System", "create", "Response")
-
     end
 
     it "can upload CRLF file format" do

--- a/spec/factories/csv_import_result.rb
+++ b/spec/factories/csv_import_result.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :csv_import_result do
+    import_errors { [] }
+  end
+end

--- a/spec/models/csv_import_result_spec.rb
+++ b/spec/models/csv_import_result_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+describe CsvImportResult, type: :model do
+  subject { build :csv_import_result }
+
+  it "can save errors" do
+    errors = %i[
+      Duplicate Client
+      CSV headers are not valid
+    ]
+
+    subject.import_errors = errors
+    subject.save
+
+    expect(subject).to be_valid
+  end
+end

--- a/spec/models/csv_import_result_spec.rb
+++ b/spec/models/csv_import_result_spec.rb
@@ -5,8 +5,13 @@ describe CsvImportResult, type: :model do
 
   it "can save errors" do
     errors = %i[
-      Duplicate Client
-      CSV headers are not valid
+      Duplicate
+      Client
+      CSV
+      headers
+      are
+      not
+      valid
     ]
 
     subject.import_errors = errors


### PR DESCRIPTION
Because CSV imports happen asynchronously, we need to persist the errors
to show to the user after the import has finished.