### PR TITLE
Update date format for certificates page

### DIFF
--- a/app/views/certificates/index.html.erb
+++ b/app/views/certificates/index.html.erb
@@ -25,7 +25,7 @@
         <tr class="govuk-table__row">
           <td class="govuk-table__cell"><%= certificate.name %></td>
           <td class="govuk-table__cell"><%= certificate.category %></td>
-          <td class="govuk-table__cell"><%= certificate.expiry_date %></td>
+          <td class="govuk-table__cell"><%= date_format(certificate.expiry_date) %></td>
           <td class="govuk-table__cell"><%= date_format(certificate.created_at) %></td>
           <td class="govuk-table__cell">
             <% if can? :manage, Certificate %>

--- a/app/views/certificates/show.html.erb
+++ b/app/views/certificates/show.html.erb
@@ -27,7 +27,7 @@
 <dl class="govuk-summary-list">
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">Expiry Date</dt>
-    <dd class="govuk-summary-list__value"><%= @certificate.expiry_date %></dd>
+    <dd class="govuk-summary-list__value"><%= date_format(@certificate.expiry_date) %></dd>
   </div>
 </dl>
 

--- a/spec/acceptance/certificate/create_certificate_spec.rb
+++ b/spec/acceptance/certificate/create_certificate_spec.rb
@@ -50,6 +50,7 @@ describe "create certificates", type: :feature do
         expect(page).to have_content("My test server certificate description details 2")
         expect(page).to have_content("Server certificate")
         expect(page).to have_content("Yes")
+        expect(page).to have_content("17-7-2021 00:00")
         expect(page).to have_content("server.pem")
 
         expect_audit_log_entry_for(editor.email, "create", "Certificate")

--- a/spec/acceptance/certificate/list_certificates_spec.rb
+++ b/spec/acceptance/certificate/list_certificates_spec.rb
@@ -12,7 +12,7 @@ describe "showing a certificate", type: :feature do
       visit "/certificates"
 
       expect(page).to have_content certificate.name
-      expect(page).to have_content certificate.expiry_date
+      expect(page).to have_content date_format(certificate.expiry_date)
       expect(page).to have_content certificate.category
       expect(page).to have_content date_format(certificate.created_at)
     end
@@ -50,10 +50,10 @@ describe "showing a certificate", type: :feature do
         first_certificate.update_attribute(:expiry_date, 2.minutes.ago)
 
         click_on "Expiry date"
-        expect(page.text).to match(/#{second_certificate.expiry_date}.*#{first_certificate.expiry_date}/)
+        expect(page.text).to match(/#{date_format(second_certificate.expiry_date)}.*#{date_format(first_certificate.expiry_date)}/)
 
         click_on "Expiry date"
-        expect(page.text).to match(/#{first_certificate.expiry_date}.*#{second_certificate.expiry_date}/)
+        expect(page.text).to match(/#{date_format(first_certificate.expiry_date)}.*#{date_format(second_certificate.expiry_date)}/)
       end
 
       it "orders by created at" do

--- a/spec/acceptance/certificate/view_certificate_spec.rb
+++ b/spec/acceptance/certificate/view_certificate_spec.rb
@@ -22,7 +22,7 @@ describe "showing a certificate", type: :feature do
 
         expect(page).to have_content certificate.name
         expect(page).to have_content certificate.category
-        expect(page).to have_content certificate.expiry_date
+        expect(page).to have_content date_format(certificate.expiry_date)
       end
 
       it "allows viewing the details of a certificate" do
@@ -30,7 +30,7 @@ describe "showing a certificate", type: :feature do
 
         expect(page).to have_content certificate.name
         expect(page).to have_content certificate.category
-        expect(page).to have_content certificate.expiry_date
+        expect(page).to have_content date_format(certificate.expiry_date)
         expect(page).to have_content certificate.subject
         expect(page).to have_content certificate.issuer
         expect(page).to have_content certificate.serial


### PR DESCRIPTION
Currently expiry dates are not consistent with the rest of the dates.
Pass the date string extracted from the certificate through the
date_format function to make it consistent.