### PR TITLE
Use long format for dates

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -17,6 +17,6 @@ module ApplicationHelper
   end
 
   def date_format(date)
-    date.strftime("%-d-%-m-%Y %H:%M")
+    date.strftime("%d/%m/%Y %H:%M")
   end
 end

--- a/app/views/audits/index.html.erb
+++ b/app/views/audits/index.html.erb
@@ -18,7 +18,7 @@
         <td class="govuk-table__cell"><%= audit.email || "System" %></td>
         <td class="govuk-table__cell"><%= audit.action %></td>
         <td class="govuk-table__cell"><%= presenter.name %></td>
-        <td class="govuk-table__cell"><%= audit.created_at.to_formatted_s(:long) %></td>
+        <td class="govuk-table__cell"><%= date_format(audit.created_at) %></td>
         <td class="govuk-table__cell"><%= link_to "Details", audit_path(audit), class: "govuk-link" %></td>
       </tr>
     <% end %>

--- a/app/views/audits/show.html.erb
+++ b/app/views/audits/show.html.erb
@@ -41,7 +41,7 @@
       Datetime
     </dt>
     <dd class="govuk-summary-list__value">
-      <%= @audit.created_at.to_s(:long) %>
+      <%= date_format(@audit.created_at) %>
     </dd>
   </div>
 </dl>

--- a/spec/acceptance/certificate/create_certificate_spec.rb
+++ b/spec/acceptance/certificate/create_certificate_spec.rb
@@ -50,7 +50,7 @@ describe "create certificates", type: :feature do
         expect(page).to have_content("My test server certificate description details 2")
         expect(page).to have_content("Server certificate")
         expect(page).to have_content("Yes")
-        expect(page).to have_content("17-7-2021 00:00")
+        expect(page).to have_content("17/07/2021 00:00")
         expect(page).to have_content("server.pem")
 
         expect_audit_log_entry_for(editor.email, "create", "Certificate")

--- a/spec/support/view_format_helpers.rb
+++ b/spec/support/view_format_helpers.rb
@@ -1,3 +1,3 @@
 def date_format(date)
-  date.strftime("%-d-%-m-%Y %H:%M")
+  date.strftime("%d/%m/%Y %H:%M")
 end


### PR DESCRIPTION
Instead of 1-1-2022 00:00 use 01/01/2022 00:00

Also ensure that audit logs follow the existing format.