### PR TITLE
Improve certificate upload times

### DIFF
--- a/app/controllers/certificates_controller.rb
+++ b/app/controllers/certificates_controller.rb
@@ -83,7 +83,7 @@ private
   end
 
   def publish_certificate(certificate_file, filename)
-    content = certificate_file.to_io
+    content = IO.read(certificate_file.to_io)
 
     UseCases::PublishToS3.new(
       config_validator: UseCases::ConfigValidator.new(


### PR DESCRIPTION
Passing a Tempfile to the S3 Ruby SDK is very slow.
Call IO.read on the content before it's sent to the SDK.
This improves upload speeds significantly.