### PR TITLE
Catch unexpected errors while importing CSV data

### DIFF
--- a/app/jobs/mac_authentication_bypass_import_job.rb
+++ b/app/jobs/mac_authentication_bypass_import_job.rb
@@ -12,6 +12,10 @@ class MacAuthenticationBypassImportJob < ActiveJob::Base
 
       csv_import_result.update!(completed_at: Time.now)
     end
+  rescue StandardError => e
+    csv_import_result.update!(import_errors: "Error while importing data from CSV: #{e.message}", completed_at: Time.now)
+
+    raise e
   end
 
 private

--- a/app/jobs/sites_with_clients_import_job.rb
+++ b/app/jobs/sites_with_clients_import_job.rb
@@ -11,6 +11,10 @@ class SitesWithClientsImportJob < ActiveJob::Base
       end
 
       csv_import_result.update!(completed_at: Time.now)
+    rescue StandardError => e
+      csv_import_result.update!(import_errors: "Error while importing data from CSV: #{e.message}", completed_at: Time.now)
+
+      raise e
     end
   end
 


### PR DESCRIPTION
### Context
When a delayed job fails, unexpected errors are captured by sentry. We want to show the errors so users know there was an issue.

### Before:
![Screenshot 2022-02-08 at 10 01 00](https://user-images.githubusercontent.com/22743709/152965776-07a59574-bad4-421f-8069-a6fed71d51bb.png)

### After:
![Screenshot 2022-02-08 at 10 03 43](https://user-images.githubusercontent.com/22743709/152965810-0af31d4d-1d4f-4b65-8d4a-89f877a3b71e.png)
