### PR TITLE
Allow filtering of audit logs

### DIFF
--- a/app/controllers/audits_controller.rb
+++ b/app/controllers/audits_controller.rb
@@ -2,7 +2,17 @@ class AuditsController < ApplicationController
   before_action :set_crumbs, only: %i[index show]
 
   def index
-    @q = Audit.ransack(params[:q])
+    @auditable_types = Audit.distinct.pluck(:auditable_type)
+    @auditable_actions = Audit.distinct.pluck(:action)
+    @selected_type = params.dig(:q, :auditable_type)
+    @selected_action = params.dig(:q, :action)
+
+    @q = Audit
+    @q = @q.where(auditable_type: @selected_type) unless @selected_type.nil?
+    @q = @q.where(action: @selected_action) unless @selected_action.nil?
+    @q = @q.ransack(params[:q])
+    @q.sorts = params.dig(:q, :s) || "created_at desc"
+
     @audits = @q.result.page(params.dig(:q, :page))
   end
 

--- a/app/views/audits/index.html.erb
+++ b/app/views/audits/index.html.erb
@@ -1,7 +1,25 @@
 <h2 class="govuk-heading-l">Audit Log</h2>
+<div>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+    </div>
+    <div class="govuk-grid-column-full">
+      <div class="govuk-grid-row">
+        <%= search_form_for @q do |f| %>
+          <div class="govuk-grid-column-two-thirds">
+          &nbsp;
+          </div>
+            <div class="govuk-grid-column-one-thirds">
+              <%= f.select(:action, @auditable_actions, { selected: @selected_action }, { class: "govuk-select" }) %>
+              <%= f.select(:auditable_type, @auditable_types, { selected: @selected_type }, { class: "govuk-select" }) %>
+              <%= f.submit "Search", { class: "govuk-button", "data-module" => "govuk-button" } %>
+            </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
 
-<table class="govuk-table">
-  <caption class="govuk-table__caption">List of audited changes</caption>
+<table class="govuk-table" id="audit-results">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th scope="col" class="govuk-table__header">User</th>

--- a/spec/acceptance/audits/search_spec.rb
+++ b/spec/acceptance/audits/search_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+describe "filtering audits", type: :feature do
+  context "when the user is authenticated" do
+    before do
+      login_as create(:user, :reader)
+    end
+
+    context "when multiple audits exists" do
+      let!(:first_audit) { create(:audit, action: "create", auditable_type: "Response") }
+      let!(:second_audit) { create(:audit, action: "update", auditable_type: "Site") }
+      let!(:third_audit) { create(:audit, action: "destroy", auditable_type: "MacAuthenticationBypass") }
+
+      before do
+        visit "/audits"
+      end
+
+      it "finds an audit" do
+        select "Site", from: "q_auditable_type"
+        select "update", from: "q_action"
+
+        click_on "Search"
+
+        expect(page).to have_select("q_auditable_type", selected: "Site")
+        expect(page).to have_select("q_action", selected: "update")
+
+        within("#audit-results") do
+          expect(page).to have_content second_audit.auditable_type
+          expect(page).to_not have_content first_audit.auditable_type
+          expect(page).to_not have_content third_audit.auditable_type
+        end
+      end
+
+      it "does not find an audit" do
+        select "Site", from: "q_auditable_type"
+        select "create", from: "q_action"
+
+        click_on "Search"
+
+        within("#audit-results") do
+          expect(page).to_not have_content second_audit.auditable_type
+          expect(page).to_not have_content first_audit.auditable_type
+          expect(page).to_not have_content third_audit.auditable_type
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds two dropdowns:
Type (Site, Client .etc)
Action (create, update, destroy)

These can be used to narrow down the audit logs.
<img width="799" alt="Screenshot 2022-02-08 at 15 44 00" src="https://user-images.githubusercontent.com/1215147/153022563-67a5c328-d988-4664-b511-cc432ecb5b1e.png">

