### PR TITLE
Add CSV file extension validation

### DIFF
--- a/app/controllers/mac_authentication_bypasses_imports_controller.rb
+++ b/app/controllers/mac_authentication_bypasses_imports_controller.rb
@@ -9,10 +9,11 @@ class MacAuthenticationBypassesImportsController < ApplicationController
   end
 
   def create
+    filename = mac_authentication_bypasses_import_params.fetch(:file).original_filename
     contents = mac_authentication_bypasses_import_params.fetch(:file).read
 
     csv_import_result = CsvImportResult.create!
-    MacAuthenticationBypassImportJob.perform_later(contents, csv_import_result, current_user)
+    MacAuthenticationBypassImportJob.perform_later({ contents: contents, filename: filename }, csv_import_result, current_user)
 
     redirect_to mac_authentication_bypasses_import_path(csv_import_result), notice: "Importing MAC addresses"
   end

--- a/app/controllers/mac_authentication_bypasses_imports_controller.rb
+++ b/app/controllers/mac_authentication_bypasses_imports_controller.rb
@@ -13,7 +13,7 @@ class MacAuthenticationBypassesImportsController < ApplicationController
     contents = mac_authentication_bypasses_import_params.fetch(:file).read
 
     csv_import_result = CsvImportResult.create!
-    MacAuthenticationBypassImportJob.perform_later({ contents: contents, filename: filename }, csv_import_result, current_user)
+    MacAuthenticationBypassImportJob.perform_later({ contents:, filename: }, csv_import_result, current_user)
 
     redirect_to mac_authentication_bypasses_import_path(csv_import_result), notice: "Importing MAC addresses"
   end

--- a/app/controllers/sites_imports_controller.rb
+++ b/app/controllers/sites_imports_controller.rb
@@ -9,10 +9,11 @@ class SitesImportsController < ApplicationController
   end
 
   def create
+    filename = params&.dig(:sites_with_clients, :file)&.original_filename
     contents = params&.dig(:sites_with_clients, :file)&.read
 
     csv_import_result = CsvImportResult.create!
-    SitesWithClientsImportJob.perform_later(contents, csv_import_result, current_user)
+    SitesWithClientsImportJob.perform_later({ contents: contents, filename: filename }, csv_import_result, current_user)
 
     redirect_to sites_import_path(csv_import_result), notice: "Importing sites with clients"
   end

--- a/app/controllers/sites_imports_controller.rb
+++ b/app/controllers/sites_imports_controller.rb
@@ -13,7 +13,7 @@ class SitesImportsController < ApplicationController
     contents = params&.dig(:sites_with_clients, :file)&.read
 
     csv_import_result = CsvImportResult.create!
-    SitesWithClientsImportJob.perform_later({ contents: contents, filename: filename }, csv_import_result, current_user)
+    SitesWithClientsImportJob.perform_later({ contents:, filename: }, csv_import_result, current_user)
 
     redirect_to sites_import_path(csv_import_result), notice: "Importing sites with clients"
   end

--- a/app/lib/use_cases/CSV_import/base.rb
+++ b/app/lib/use_cases/CSV_import/base.rb
@@ -1,7 +1,8 @@
 module UseCases
   class CSVImport::Base
     def initialize(csv_contents = nil)
-      @csv_contents = remove_utf8_byte_order_mark(csv_contents) if csv_contents
+      @csv_contents = remove_utf8_byte_order_mark(csv_contents&.fetch(:contents)) if csv_contents&.fetch(:contents)
+      @filename = csv_contents&.fetch(:filename)
       @records = []
       @errors = []
     end
@@ -33,6 +34,10 @@ module UseCases
         response_attribute, value = r.split("=")
         Response.new(response_attribute:, value:)
       end
+    end
+
+    def valid_file_extension?
+      @filename.split(".")[1] == "csv"
     end
 
     def valid_header?(csv_headers)

--- a/app/lib/use_cases/CSV_import/mac_authentication_bypasses.rb
+++ b/app/lib/use_cases/CSV_import/mac_authentication_bypasses.rb
@@ -59,6 +59,7 @@ module UseCases
 
     def valid_csv?
       return @errors << "CSV is missing" && false if @csv_contents.nil?
+      return @errors << "The file extension is invalid" && false unless valid_file_extension?
       return @errors << "The CSV header is invalid" && false unless valid_header?(CSV_HEADERS)
       return @errors << "There is no data to be imported" && false unless @csv_contents.split("\n").second
 

--- a/app/lib/use_cases/CSV_import/sites_with_clients.rb
+++ b/app/lib/use_cases/CSV_import/sites_with_clients.rb
@@ -45,6 +45,7 @@ module UseCases
 
     def valid_csv?
       return @errors << "CSV is missing" && false if @csv_contents.nil?
+      return @errors << "The file extension is invalid" && false unless valid_file_extension?
       return @errors << "The CSV header is invalid" && false unless valid_header?(CSV_HEADERS)
       return @errors << "There is no data to be imported" && false unless @csv_contents.split("\n").second
 

--- a/spec/acceptance/mac_authentication_bypass/import_spec.rb
+++ b/spec/acceptance/mac_authentication_bypass/import_spec.rb
@@ -194,5 +194,22 @@ describe "Import MAC Authentication Bypasses", type: :feature do
 
       expect(page).to have_content("Error while importing data from CSV: something bad")
     end
+
+    it "shows error when the file extension is not .csv" do
+      visit "/mac_authentication_bypasses"
+
+      click_on "Import bypasses"
+
+      attach_file("csv_file", "spec/fixtures/shared/invalid.ext")
+      click_on "Upload"
+
+      Delayed::Worker.new.work_off
+
+      click_on "here"
+
+      expect(page).to have_content("There is a problem")
+
+      expect(page).to have_content("The file extension is invalid")
+    end
   end
 end

--- a/spec/acceptance/sites/import_spec.rb
+++ b/spec/acceptance/sites/import_spec.rb
@@ -177,5 +177,22 @@ describe "Import Sites with Clients", type: :feature do
 
       expect(page).to have_content("Error while importing data from CSV: something bad")
     end
+
+    it "shows error when the file extension is not .csv" do
+      visit "/sites"
+
+      click_on "Import sites with clients"
+
+      attach_file("csv_file", "spec/fixtures/shared/invalid.ext")
+      click_on "Upload"
+
+      Delayed::Worker.new.work_off
+
+      click_on "here"
+
+      expect(page).to have_content("There is a problem")
+
+      expect(page).to have_content("The file extension is invalid")
+    end
   end
 end

--- a/spec/use_cases/CSV_import/mac_authentication_bypasses_spec.rb
+++ b/spec/use_cases/CSV_import/mac_authentication_bypasses_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe UseCases::CSVImport::MacAuthenticationBypasses do
-  subject { described_class.new(file_contents) }
+  subject { described_class.new({ contents: file_contents, filename: "dummy.csv" }) }
 
   context "valid csv entries" do
     before do

--- a/spec/use_cases/CSV_import/sites_with_clients_spec.rb
+++ b/spec/use_cases/CSV_import/sites_with_clients_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe UseCases::CSVImport::SitesWithClients do
-  subject { described_class.new(file_contents) }
+  subject { described_class.new({ contents: file_contents, filename: "dummy.csv" }) }
 
   context "valid csv entries" do
     before do


### PR DESCRIPTION
## Context

- this checks the file extension when importing MAC Authentication Bypasses and Sites with Clients
  - an error is displayed when the filename contains an invalid extension (anything other than `.csv`)