### PR TITLE
Default sort order for sites

### DIFF
--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -13,6 +13,7 @@ class SitesController < ApplicationController
            Site.ransack(params[:q])
          end
 
+    @q.sorts = params.dig(:q, :s) || "created_at desc"
     @sites = @q.result(distinct: true).page(params.dig(:q, :page))
   end
 

--- a/spec/acceptance/sites/list_sites_spec.rb
+++ b/spec/acceptance/sites/list_sites_spec.rb
@@ -36,6 +36,16 @@ describe "listing sites", type: :feature do
         visit "/sites"
       end
 
+      it "orders sites by create date by default" do
+        first_site.update(created_at: DateTime.now - 2.hours)
+        second_site.update(created_at: DateTime.now - 1.hour)
+        third_site.update(created_at: DateTime.now - 3.hours)
+
+        visit "/sites"
+
+        expect(page.text).to match(/#{second_site.name}.*#{first_site.name}.*#{third_site.name}/)
+      end
+
       it "searches by name" do
         expect(page).to have_content first_site.name
         expect(page).to have_content second_site.name
@@ -79,17 +89,17 @@ describe "listing sites", type: :feature do
 
     context "pagination" do
       it "paginates" do
-        52.times do |t|
-          create(:site, name: "Site #{t}")
-        end
+        50.times { create(:site) }
+
+        create(:site, name: "Last Site", created_at: DateTime.now - 2.hours)
 
         visit "/sites"
 
-        expect(page.text).to_not include("Site 51")
+        expect(page.text).to_not include("Last Site")
 
         click_on "2"
 
-        expect(page.text).to include("Site 51")
+        expect(page.text).to include("Last Site")
       end
     end
   end


### PR DESCRIPTION
List sites in descending create date order unless manually sorted.