### PR TITLE
Use File#extname for .csv validation

### DIFF
--- a/app/lib/use_cases/CSV_import/base.rb
+++ b/app/lib/use_cases/CSV_import/base.rb
@@ -37,7 +37,7 @@ module UseCases
     end
 
     def valid_file_extension?
-      @filename.split(".")[1] == "csv"
+      File.extname(@filename) == ".csv"
     end
 
     def valid_header?(csv_headers)

--- a/app/views/mac_authentication_bypasses_imports/new.html.erb
+++ b/app/views/mac_authentication_bypasses_imports/new.html.erb
@@ -8,7 +8,7 @@
       For example: Tunnel-Type=VLAN;Reply-Message=Welcome;SG-Tunnel-Id=333<br /><br />
       File must be a valid CSV with UTF-8 encoding.<br />
     </div>
-    <%= file_field :bypasses, :file, { id: :csv_file, class: "govuk-file-upload", required: true } %>
+    <%= file_field :bypasses, :file, { id: :csv_file, accept: ".csv", class: "govuk-file-upload", required: true } %>
   </div>
 
   <%= submit_tag "Upload", {

--- a/app/views/sites_imports/new.html.erb
+++ b/app/views/sites_imports/new.html.erb
@@ -12,7 +12,7 @@
       For example: Tunnel-Type=VLAN;Reply-Message=Welcome;SG-Tunnel-Id=333<br /><br />
       File must be a valid CSV with UTF-8 encoding.<br />
     </div>
-    <%= file_field :sites_with_clients, :file, { id: :csv_file, class: "govuk-file-upload", required: true } %>
+    <%= file_field :sites_with_clients, :file, { id: :csv_file, accept: ".csv", class: "govuk-file-upload", required: true } %>
   </div>
 
   <%= submit_tag "Upload", {


### PR DESCRIPTION
## Context

- this is to ensure we pull out the correct file extension when importing MAC Authentication Bypasses and Sites with Clients
  - only allow .csv files to be uploaded on the import pages