### PR TITLE
Add auto-refresh for CSV import progress

### DIFF
--- a/app/views/layouts/_import.html.erb
+++ b/app/views/layouts/_import.html.erb
@@ -13,10 +13,10 @@
                 </div>
             </div>
         <% else %>
-            <span id="success">CSV Successfully imported</span>
+            <span id="success">CSV successfully imported!</span>
         <% end %>
     <% else %>
-        Import in progress... <noscript>Click <%= link_to "here", path, class: "govuk-link" %> to refresh.</noscript>
+        Import is in progress, please wait... <noscript>Click <%= link_to "here", path, class: "govuk-link" %> to refresh.</noscript>
     <% end %>
 </p>
 

--- a/app/views/layouts/_import.html.erb
+++ b/app/views/layouts/_import.html.erb
@@ -3,19 +3,25 @@
     <% if @csv_import_result.completed_at.present? %>
         <% if @csv_import_result.import_errors.present? %>
             <div class="govuk-error-summary" id="error-summary">
-            <h2 class="govuk-error-summary__title">There is a problem</h2>
-            <div class="govuk-error-summary__body">
-                <ul class="govuk-list govuk-error-summary__list">
-                <% @csv_import_result.import_errors.split(",").each do |error| %>
-                    <li id="error-message"><%= error %></li>
-                <% end %>
-                </ul>
-            </div>
+                <h2 class="govuk-error-summary__title">There is a problem</h2>
+                <div class="govuk-error-summary__body">
+                    <ul class="govuk-list govuk-error-summary__list">
+                    <% @csv_import_result.import_errors.split(",").each do |error| %>
+                        <li id="error-message"><%= error %></li>
+                    <% end %>
+                    </ul>
+                </div>
             </div>
         <% else %>
-            CSV Successfully imported
+            <span id="success">CSV Successfully imported</span>
         <% end %>
     <% else %>
-        Import in progress.. Click <%= link_to "here", path, class: "govuk-link" %> to refresh.
+        Import in progress... <noscript>Click <%= link_to "here", path, class: "govuk-link" %> to refresh.</noscript>
     <% end %>
 </p>
+
+<script>
+if(!document.getElementById("success") && !document.getElementById("error-message")){
+    setTimeout("location.reload(true);", 2000);
+}
+</script>

--- a/spec/acceptance/mac_authentication_bypass/import_spec.rb
+++ b/spec/acceptance/mac_authentication_bypass/import_spec.rb
@@ -55,7 +55,8 @@ describe "Import MAC Authentication Bypasses", type: :feature do
       expect(CsvImportResult.all.count).to eq(1)
       expect(CsvImportResult.first.errors).to be_empty
 
-      expect(page).to have_text("Import in progress.. Click here to refresh.")
+      expect(page).to have_text("Import in progress...")
+      expect(page).to have_text("Click here to refresh.")
 
       click_on "here"
 

--- a/spec/acceptance/mac_authentication_bypass/import_spec.rb
+++ b/spec/acceptance/mac_authentication_bypass/import_spec.rb
@@ -55,13 +55,13 @@ describe "Import MAC Authentication Bypasses", type: :feature do
       expect(CsvImportResult.all.count).to eq(1)
       expect(CsvImportResult.first.errors).to be_empty
 
-      expect(page).to have_text("Import in progress...")
+      expect(page).to have_text("Import is in progress, please wait...")
       expect(page).to have_text("Click here to refresh.")
 
       click_on "here"
 
       expect(page.current_path).to eq(mac_authentication_bypasses_import_path(CsvImportResult.last.id))
-      expect(page).to have_content("CSV Successfully imported")
+      expect(page).to have_content("CSV successfully imported!")
 
       visit "/mac_authentication_bypasses"
 

--- a/spec/acceptance/policy/import_spec.rb
+++ b/spec/acceptance/policy/import_spec.rb
@@ -51,13 +51,13 @@ describe "Import Policies", type: :feature do
       expect(CsvImportResult.all.count).to eq(1)
       expect(CsvImportResult.first.errors).to be_empty
 
-      expect(page).to have_text("Import in progress...")
+      expect(page).to have_text("Import is in progress, please wait...")
       expect(page).to have_text("Click here to refresh.")
 
       click_on "here"
 
       expect(page.current_path).to eq(policies_import_path(CsvImportResult.last.id))
-      expect(page).to have_content("CSV Successfully imported")
+      expect(page).to have_content("CSV successfully imported!")
 
       visit "/policies"
 

--- a/spec/acceptance/policy/import_spec.rb
+++ b/spec/acceptance/policy/import_spec.rb
@@ -51,7 +51,8 @@ describe "Import Policies", type: :feature do
       expect(CsvImportResult.all.count).to eq(1)
       expect(CsvImportResult.first.errors).to be_empty
 
-      expect(page).to have_text("Import in progress.. Click here to refresh.")
+      expect(page).to have_text("Import in progress...")
+      expect(page).to have_text("Click here to refresh.")
 
       click_on "here"
 

--- a/spec/acceptance/sites/import_spec.rb
+++ b/spec/acceptance/sites/import_spec.rb
@@ -54,13 +54,13 @@ describe "Import Sites with Clients", type: :feature do
       Delayed::Worker.new.work_off
       expect(Delayed::Job.count).to eq(0)
 
-      expect(page).to have_text("Import in progress...")
+      expect(page).to have_text("Import is in progress, please wait...")
       expect(page).to have_text("Click here to refresh.")
 
       click_on "here"
 
       expect(page.current_path).to eq(sites_import_path(CsvImportResult.last.id))
-      expect(page).to have_content("CSV Successfully imported")
+      expect(page).to have_content("CSV successfully imported!")
 
       visit "/sites"
 

--- a/spec/acceptance/sites/import_spec.rb
+++ b/spec/acceptance/sites/import_spec.rb
@@ -54,7 +54,8 @@ describe "Import Sites with Clients", type: :feature do
       Delayed::Worker.new.work_off
       expect(Delayed::Job.count).to eq(0)
 
-      expect(page).to have_text("Import in progress.. Click here to refresh.")
+      expect(page).to have_text("Import in progress...")
+      expect(page).to have_text("Click here to refresh.")
 
       click_on "here"
 


### PR DESCRIPTION
## Context

- this allows users to have a seamless experience where the import progress page is auto-refreshed
- this also allows users with browsers that have JavaScript disabled to manually refresh