### PR TITLE
Add sections on Certificates page

### DIFF
--- a/app/views/certificates/index.html.erb
+++ b/app/views/certificates/index.html.erb
@@ -28,18 +28,59 @@
       </tr>
     </thead>
     <tbody class="govuk-table__body">
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell govuk-!-font-weight-bold" colspan="2" style="text-align:center">SERVER CERTIFICATES</td>
+      </tr>
       <% @certificates.each do |certificate| %>
-        <tr class="govuk-table__row">
-          <td class="govuk-table__cell"><%= certificate.name %></td>
-          <td class="govuk-table__cell"><%= certificate.category %></td>
-          <td class="govuk-table__cell"><%= date_format(certificate.expiry_date) %></td>
-          <td class="govuk-table__cell"><%= date_format(certificate.created_at) %></td>
-          <td class="govuk-table__cell">
-            <% if can? :manage, Certificate %>
-              <%= link_to "View", certificate_path(certificate), class:"govuk-link" %>
-            <% end %>
-          </td>
-        </tr>
+        <% if certificate.filename == "server.pem" %>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><%= certificate.name %></td>
+            <td class="govuk-table__cell"><%= certificate.category %></td>
+            <td class="govuk-table__cell"><%= date_format(certificate.expiry_date) %></td>
+            <td class="govuk-table__cell"><%= date_format(certificate.created_at) %></td>
+            <td class="govuk-table__cell">
+              <% if can? :manage, Certificate %>
+                <%= link_to "View", certificate_path(certificate), class:"govuk-link" %>
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
+      <% end %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell govuk-!-font-weight-bold" colspan="2" style="text-align:center">END-USER TRUST CERTIFICATES</td>
+      </tr>
+      <% @certificates.each do |certificate| %>
+        <% if certificate.category == "EAP" && certificate.filename != "server.pem" %>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><%= certificate.name %></td>
+            <td class="govuk-table__cell"><%= certificate.category %></td>
+            <td class="govuk-table__cell"><%= date_format(certificate.expiry_date) %></td>
+            <td class="govuk-table__cell"><%= date_format(certificate.created_at) %></td>
+            <td class="govuk-table__cell">
+              <% if can? :manage, Certificate %>
+                <%= link_to "View", certificate_path(certificate), class:"govuk-link" %>
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
+      <% end %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell govuk-!-font-weight-bold" colspan="2" style="text-align:center">INFRASTRUCTURE CERTIFICATES</td>
+      </tr>
+      <% @certificates.each do |certificate| %>
+        <% if certificate.category == "RADSEC" && certificate.filename != "server.pem" %>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><%= certificate.name %></td>
+            <td class="govuk-table__cell"><%= certificate.category %></td>
+            <td class="govuk-table__cell"><%= date_format(certificate.expiry_date) %></td>
+            <td class="govuk-table__cell"><%= date_format(certificate.created_at) %></td>
+            <td class="govuk-table__cell">
+              <% if can? :manage, Certificate %>
+                <%= link_to "View", certificate_path(certificate), class:"govuk-link" %>
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
       <% end %>
     </tbody>
   </table>

--- a/spec/acceptance/certificate/list_certificates_spec.rb
+++ b/spec/acceptance/certificate/list_certificates_spec.rb
@@ -65,8 +65,8 @@ describe "showing a certificate", type: :feature do
       end
 
       it "orders by category" do
-        second_certificate.update_attribute(:category, "EAP")
-        first_certificate.update_attribute(:category, "RADSEC")
+        second_certificate.update(category: "EAP", filename: "server.pem")
+        first_certificate.update(category: "RADSEC", filename: "server.pem")
 
         click_on "Category"
         expect(page.text).to match(/EAP.*RADSEC/)


### PR DESCRIPTION
## Context

- add sections to distinguish between certificate types
  - server certificates
  - end-user trust certificates
  - infrastructure certificates
 
### Screenshot

![image](https://user-images.githubusercontent.com/47318342/155510532-11686b39-a098-4c3c-876c-d1caaa74d794.png)
