### PR TITLE
Update Site name length limit

### DIFF
--- a/app/views/sites/_form.html.erb
+++ b/app/views/sites/_form.html.erb
@@ -5,7 +5,7 @@
       Must contain the FITS ID, and location in the following format: "FITS_XXX_LOCATION"<br />
       For example: FITS_4591_MAIDSTONE
     </div>
-    <%= f.text_field :name, maxlength: 255, class: "govuk-input" %>
+    <%= f.text_field :name, maxlength: 230, class: "govuk-input" %>
   </div>
 
   <%= f.submit f.object.new_record? ? "Create" : "Update", {


### PR DESCRIPTION
### Context
Fallback policy name generated from site name, therefore site name should be shorter than the max possible fallback policy name 
![image](https://user-images.githubusercontent.com/22743709/155547279-a8b98980-8958-4d12-8105-2b67620acb74.png)