### PR TITLE
Update Site Policy order priority to be unique

### DIFF
--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -90,12 +90,16 @@ class SitesController < ApplicationController
   end
 
   def update_site_policies
-    @site_policies.each do |site_policy|
-      priority = site_policies_params.fetch(site_policy.id.to_s)
-      site_policy.update(priority:)
-    end
+    if site_policies_params.values == site_policies_params.values.uniq
+      @site_policies.each do |site_policy|
+        priority = site_policies_params.fetch(site_policy.id.to_s)
+        site_policy.update(priority:)
+      end
 
-    redirect_to site_path(@site), notice: "Successfully updated the order of site policies."
+      redirect_to site_path(@site), notice: "Successfully updated the order of site policies."
+    else
+      redirect_to edit_site_policies_path(@site), alert: "Duplicate values entered for order priority."
+    end
   end
 
 private

--- a/spec/acceptance/sites/order_site_policies_spec.rb
+++ b/spec/acceptance/sites/order_site_policies_spec.rb
@@ -61,6 +61,19 @@ describe "order site policies", type: :feature do
       end
     end
 
+    it "does not allow same order priority" do
+      visit "/sites/#{site.id}"
+
+      click_on "Change priorities"
+
+      fill_in "Most Important Policy", with: "10"
+      fill_in "Least Important Policy", with: "10"
+
+      click_on "Update"
+
+      expect(page).to have_content("Duplicate values entered for order priority.")
+    end
+
     context "when there is a fallback policy" do
       let(:fallback_policy) { create(:policy, name: "Fallback Policy", fallback: true) }
 


### PR DESCRIPTION
## Context

- display an error if there are duplicate values entered when changing/updating priorities