### PR TITLE
Prevent ECS deploy error

### DIFF
--- a/app/lib/use_cases/deploy_service.rb
+++ b/app/lib/use_cases/deploy_service.rb
@@ -6,6 +6,8 @@ module UseCases
 
     def call
       ecs_gateway.update_service
+    rescue RuntimeError
+      p "NOOP: Deployments have already been scheduled"
     end
 
   private


### PR DESCRIPTION
ECS only allows a maximum of 5 deployments at one time.
When deployments are already scheduled, we don't need to schedule more.

Ignore deployments once we have 5 scheduled.