### PR TITLE
Reset all databases to 0

### DIFF
--- a/scripts/seed.sh
+++ b/scripts/seed.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 source ./scripts/aws_helpers.sh
 
 seed() {
-  local seed_command="./bin/rails DISABLE_DATABASE_ENVIRONMENT_CHECK=1 db:seed"
+  local seed_command="./bin/rails DISABLE_DATABASE_ENVIRONMENT_CHECK=1 db:migrate:reset"
   local docker_service_name="admin"
   local cluster_name service_name task_definition docker_service_name
 


### PR DESCRIPTION
As we approach going live, we want to reset all test data and indexes so
we can create only the data that's required.