### PR TITLE
Explicit max-connections config

### DIFF
--- a/app/lib/use_cases/generate_authorised_clients.rb
+++ b/app/lib/use_cases/generate_authorised_clients.rb
@@ -27,6 +27,9 @@ private
     str << "\n\t\tsecret = #{client.shared_secret}"
     str << "\n\t\tshortname = #{client.site.tag}"
     str << "\n\t\tproto = tls"
+    str << "\n\t\tlimit {"
+    str << "\n\t\t\tmax_connections = 0"
+    str << "\n\t\t}"
     str << "\n\t}\n"
   end
 end

--- a/spec/use_cases/generate_authorised_clients_spec.rb
+++ b/spec/use_cases/generate_authorised_clients_spec.rb
@@ -59,6 +59,9 @@ clients radsec {
 \t\tsecret = radsec
 \t\tshortname = #{first_radsec_client.site.tag}
 \t\tproto = tls
+\t\tlimit {
+\t\t\tmax_connections = 0
+\t\t}
 \t}
 
 \tclient #{second_radsec_client.ip_range} {
@@ -66,6 +69,9 @@ clients radsec {
 \t\tsecret = radsec
 \t\tshortname = #{second_radsec_client.site.tag}
 \t\tproto = tls
+\t\tlimit {
+\t\t\tmax_connections = 0
+\t\t}
 \t}\n
 }"
           expect(result).to eq(expected_config)


### PR DESCRIPTION
This defaults to 16, which isn't suitable for production use.
Set to infinite to allow many authenticators to connect at the same
time.