### PR TITLE
:lipstick: Change Site column widths

### DIFF
--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -24,10 +24,10 @@
     <caption class="govuk-table__caption">List of sites</caption>
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
-        <th scope="col" class="govuk-table__header"><%= sort_link(@q, :name) %></th>
+        <th scope="col" class="govuk-table__header govuk-!-width-one-half"><%= sort_link(@q, :name) %></th>
         <th scope="col" class="govuk-table__header"><%= sort_link(@q, :created_at) %></th>
         <th scope="col" class="govuk-table__header"><%= sort_link(@q, :updated_at) %></th>
-        <th scope="col" class="govuk-table__header">
+        <th scope="col" class="govuk-table__header govuk-table__narrow">
           <span class="govuk-visually-hidden">Actions</span>
         </th>
       </tr>
@@ -35,10 +35,10 @@
     <tbody class="govuk-table__body">
       <% @sites.each do |site| %>
         <tr class="govuk-table__row" id="site-row-<%= site.id %>">
-          <td class="govuk-table__cell"><%= site.name %></td>
+          <td class="govuk-table__cell govuk-!-width-one-half"><%= site.name %></td>
           <td class="govuk-table__cell"><%= date_format(site.created_at) %></td>
           <td class="govuk-table__cell"><%= date_format(site.updated_at) %></td>
-          <td class="govuk-table__cell">
+          <td class="govuk-table__cell govuk-table__narrow">
             <% if can? :manage, Site %>
               <%= link_to "Manage", site_path(site), class: "govuk-link" %>
             <% else %>


### PR DESCRIPTION
Used gov uk overide classes to change the site name width to one half of page.
Used the gov uk table narrow css  and applied to the actions column.