### PR TITLE
:lock: Create default reject policy for sites csv import.

### DIFF
--- a/app/lib/use_cases/CSV_import/sites_with_clients.rb
+++ b/app/lib/use_cases/CSV_import/sites_with_clients.rb
@@ -14,7 +14,7 @@ module UseCases
         eap_clients = row["RADIUS Clients"]
         radsec_clients = row["RadSec Clients"]
         policies = row["Policies"]
-        fallback_policy = row["Fallback Policy Responses"]
+        fallback_policy_responses = row["Fallback Policy Responses"]
 
         record = Site.new(
           name: site_name,
@@ -24,9 +24,10 @@ module UseCases
           name: "Fallback policy for #{site_name}",
           description: "Default fallback policy for #{site_name}",
           fallback: true,
+          action: fallback_policy_responses.nil? ? "reject" : "accept"
         )
 
-        unwrap_responses(fallback_policy).each do |fallback_policy_response|
+        unwrap_responses(fallback_policy_responses).each do |fallback_policy_response|
           record.policies.first.responses << fallback_policy_response
         end
 

--- a/spec/acceptance/sites/import_spec.rb
+++ b/spec/acceptance/sites/import_spec.rb
@@ -76,6 +76,8 @@ describe "Import Sites with Clients", type: :feature do
 
       click_on "Fallback policy for Site 1"
 
+      expect(page).to have_content("Action")
+      expect(page).to have_content("Accept")
       expect(page).to have_content("Dlink-VLAN-ID")
       expect(page).to have_content("888")
       expect(page).to have_content("Reply-Message")
@@ -89,6 +91,8 @@ describe "Import Sites with Clients", type: :feature do
 
       click_on "Fallback policy for Site 2"
 
+      expect(page).to have_content("Action")
+      expect(page).to have_content("Accept")
       expect(page).to have_content("Dlink-VLAN-ID")
       expect(page).to have_content("888")
       expect(page).to have_content("Reply-Message")
@@ -103,6 +107,11 @@ describe "Import Sites with Clients", type: :feature do
       expect(page).to have_content("Test Policy 2")
       expect(page).to have_content("Fallback policy for Site 3")
 
+      click_on "Fallback policy for Site 3"
+
+      expect(page).to have_content("Post-Auth-Type")
+      expect(page).to have_content("Reject")
+      
       expect_audit_log_entry_for(editor.email, "create", "Site")
       expect_audit_log_entry_for(editor.email, "create", "Site policy")
       expect_audit_log_entry_for(editor.email, "create", "Client")

--- a/spec/use_cases/CSV_import/sites_with_clients_spec.rb
+++ b/spec/use_cases/CSV_import/sites_with_clients_spec.rb
@@ -83,7 +83,7 @@ Petty France,128.0.0.1,,,"
       subject.call
     end
 
-    it "creates valid sites and fallback policies with no responses" do
+    it "creates valid sites with default reject fallback policy" do
       saved_site = Site.find_by_name("Petty France")
 
       expect(saved_site.id).to_not be_nil
@@ -92,7 +92,8 @@ Petty France,128.0.0.1,,,"
 
       expect(saved_site.policy_count).to eq(1)
       expect(saved_site.fallback_policy.name).to eq("Fallback policy for Petty France")
-      expect(saved_site.fallback_policy.responses).to be_empty
+      expect(saved_site.fallback_policy.responses.first.response_attribute).to eq("Post-Auth-Type")
+      expect(saved_site.fallback_policy.responses.first.value).to eq("Reject")
     end
   end
 


### PR DESCRIPTION
Create a default reject policy when there are no fallback policy responses provided.