### PR TITLE
🚀 Deploy service and publish authorised_clients_config when site tag changes

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -34,6 +34,26 @@ class ApplicationController < ActionController::Base
 
 protected
 
+  def publish_authorised_clients
+    content = UseCases::GenerateAuthorisedClients.new.call(
+      clients: Client.where.not(shared_secret: "radsec").includes(:site),
+      radsec_clients: Client.where(shared_secret: "radsec").includes(:site),
+    )
+
+    UseCases::PublishToS3.new(
+      config_validator: UseCases::ConfigValidator.new(
+        config_file_path: RadiusHelper::AUTHORISED_CLIENTS_PATH,
+        content:,
+      ),
+      destination_gateway: Gateways::S3.new(
+        bucket: ENV.fetch("RADIUS_CONFIG_BUCKET_NAME"),
+        key: "clients.conf",
+        aws_config: Rails.application.config.s3_aws_config,
+        content_type: "text/plain",
+      ),
+    ).call(content)
+  end
+
   def deploy_service
     UseCases::DeployService.new(
       ecs_gateway: Gateways::Ecs.new(

--- a/app/controllers/clients_controller.rb
+++ b/app/controllers/clients_controller.rb
@@ -69,26 +69,6 @@ private
     params.require(:client).permit(:ip_range, :radsec, :shared_secret)
   end
 
-  def publish_authorised_clients
-    content = UseCases::GenerateAuthorisedClients.new.call(
-      clients: Client.where.not(shared_secret: "radsec").includes(:site),
-      radsec_clients: Client.where(shared_secret: "radsec").includes(:site),
-    )
-
-    UseCases::PublishToS3.new(
-      config_validator: UseCases::ConfigValidator.new(
-        config_file_path: RadiusHelper::AUTHORISED_CLIENTS_PATH,
-        content:,
-      ),
-      destination_gateway: Gateways::S3.new(
-        bucket: ENV.fetch("RADIUS_CONFIG_BUCKET_NAME"),
-        key: "clients.conf",
-        aws_config: Rails.application.config.s3_aws_config,
-        content_type: "text/plain",
-      ),
-    ).call(content)
-  end
-
   def set_crumbs
     @navigation_crumbs << ["Sites", sites_path]
   end

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -45,6 +45,8 @@ class SitesController < ApplicationController
     @site.assign_attributes(site_params)
 
     if @site.save
+      publish_authorised_clients
+      deploy_service
       redirect_to site_path(@site), notice: "Successfully updated site. #{CONFIG_UPDATE_DELAY_NOTICE}"
     else
       render :edit

--- a/spec/acceptance/sites/update_sites_spec.rb
+++ b/spec/acceptance/sites/update_sites_spec.rb
@@ -29,13 +29,34 @@ describe "update sites", type: :feature do
 
   context "when the user is an editor" do
     let(:editor) { create(:user, :editor) }
+    let(:config_validator) { double(UseCases::ConfigValidator) }
+    let(:publish_to_s3) { instance_double(UseCases::PublishToS3) }
+    let(:s3_gateway) { double(Gateways::S3) }
+    let(:expected_s3_gateway_config) do
+      {
+        bucket: ENV.fetch("RADIUS_CONFIG_BUCKET_NAME"),
+        key: "clients.conf",
+        aws_config: Rails.application.config.s3_aws_config,
+        content_type: "text/plain",
+      }
+    end
 
     before do
       login_as editor
       site
+      allow(publish_to_s3).to receive(:call)
     end
 
     it "update an existing site" do
+      expect_service_deployment
+      expect(Gateways::S3).to receive(:new).with(expected_s3_gateway_config).and_return(s3_gateway)
+      expect(UseCases::ConfigValidator).to receive(:new).and_return(config_validator)
+
+      expect(UseCases::PublishToS3).to receive(:new).with(
+        destination_gateway: s3_gateway,
+        config_validator:,
+      ).and_return(publish_to_s3)
+
       visit "/sites/#{site.id}"
 
       first(:link, "Change").click


### PR DESCRIPTION
This commit updates the spec to test for the case of a user updating a site, and as a result of this the tag changing also.  

As a result of this the controllers were also refactored, specifically moving the `publish_authorised_clients` method to the `application_controller` from the `clients_controller`.