### PR TITLE
🐛🚀 Fix bug when clients.conf is not regenerated after site deletion

### DIFF
--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -58,6 +58,8 @@ class SitesController < ApplicationController
 
     if confirmed?
       if @site.destroy
+        publish_authorised_clients
+        deploy_service
         redirect_to sites_path, notice: "Successfully deleted site. #{CONFIG_UPDATE_DELAY_NOTICE}"
       else
         redirect_to site_path(@site), error: "Failed to delete the site"

--- a/spec/acceptance/sites/delete_sites_spec.rb
+++ b/spec/acceptance/sites/delete_sites_spec.rb
@@ -44,7 +44,7 @@ describe "delete sites", type: :feature do
         destination_gateway: s3_gateway,
         config_validator:,
       ).and_return(publish_to_s3)
-      
+
       visit "/sites/#{site.id}"
 
       find_link("Delete site", href: "/sites/#{site.id}").click

--- a/spec/acceptance/sites/delete_sites_spec.rb
+++ b/spec/acceptance/sites/delete_sites_spec.rb
@@ -17,12 +17,34 @@ describe "delete sites", type: :feature do
 
   context "when the user is an editor" do
     let(:editor) { create(:user, :editor) }
+    let(:config_validator) { double(UseCases::ConfigValidator) }
+    let(:publish_to_s3) { instance_double(UseCases::PublishToS3) }
+    let(:s3_gateway) { double(Gateways::S3) }
+    let(:expected_s3_gateway_config) do
+      {
+        bucket: ENV.fetch("RADIUS_CONFIG_BUCKET_NAME"),
+        key: "clients.conf",
+        aws_config: Rails.application.config.s3_aws_config,
+        content_type: "text/plain",
+      }
+    end
 
     before do
       login_as editor
+      site
+      allow(publish_to_s3).to receive(:call)
     end
 
     it "delete a site" do
+      expect_service_deployment
+      expect(Gateways::S3).to receive(:new).with(expected_s3_gateway_config).and_return(s3_gateway)
+      expect(UseCases::ConfigValidator).to receive(:new).and_return(config_validator)
+
+      expect(UseCases::PublishToS3).to receive(:new).with(
+        destination_gateway: s3_gateway,
+        config_validator:,
+      ).and_return(publish_to_s3)
+      
       visit "/sites/#{site.id}"
 
       find_link("Delete site", href: "/sites/#{site.id}").click


### PR DESCRIPTION
Always regenerate, publish to S3 and deploy the service when a site is deleted. 