### PR TITLE
Update default priority when importing Sites CSV

### DIFF
--- a/app/lib/use_cases/CSV_import/sites_with_clients.rb
+++ b/app/lib/use_cases/CSV_import/sites_with_clients.rb
@@ -89,7 +89,7 @@ module UseCases
     def prioritise_policies(site)
       site_policies = site.site_policy.reject(&:fallback?)
 
-      site_policies.each.with_index do |site_policy, index|
+      site_policies.each.with_index(1) do |site_policy, index|
         site_policy.priority = index * 10
       end
     end

--- a/spec/acceptance/sites/import_spec.rb
+++ b/spec/acceptance/sites/import_spec.rb
@@ -75,7 +75,7 @@ describe "Import Sites with Clients", type: :feature do
       expect(page).to have_content("Test Policy 1")
 
       within "#site-policy-priority-#{Site.first.policies.first.id}" do
-        expect(page).to have_content("0")
+        expect(page).to have_content("10")
       end
 
       click_on "Fallback policy for Site 1"
@@ -110,13 +110,13 @@ describe "Import Sites with Clients", type: :feature do
       expect(page).to have_content("Test Policy 1")
 
       within "#site-policy-priority-#{Site.third.policies.first.id}" do
-        expect(page).to have_content("0")
+        expect(page).to have_content("10")
       end
 
       expect(page).to have_content("Test Policy 2")
 
       within "#site-policy-priority-#{Site.third.policies.second.id}" do
-        expect(page).to have_content("10")
+        expect(page).to have_content("20")
       end
 
       expect(page).to have_content("Fallback policy for Site 3")

--- a/spec/use_cases/CSV_import/sites_with_clients_spec.rb
+++ b/spec/use_cases/CSV_import/sites_with_clients_spec.rb
@@ -31,9 +31,9 @@ Petty France,128.0.0.1;10.0.0.1/32,128.0.0.1,Test Policy 1;Test Policy 2,Dlink-V
       expect(result.fallback_policy.responses.second.value).to eq("hi")
 
       expect(result.policies.first.name).to eq("Test Policy 1")
-      expect(result.site_policy.second.priority).to eq(0)
+      expect(result.site_policy.second.priority).to eq(10)
       expect(result.policies.second.name).to eq("Test Policy 2")
-      expect(result.site_policy.third.priority).to eq(10)
+      expect(result.site_policy.third.priority).to eq(20)
       expect(result.policies.third.name).to eq("Fallback policy for Petty France")
 
       expect(result.clients.first.radsec).to be_falsey


### PR DESCRIPTION
## Context

- Update priority to start from 10 instead of 0.