### PR TITLE
:wrench: Update GitHub Ruby version

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.2.1'
+        ruby-version: '3.2.2'
 
     - name: Format code
       env:


### PR DESCRIPTION
This version `3.2.1`, is not inline with the version the application is sitting at - `3.2.2`. As a result GitHub format-code Actions are failing.