### PR TITLE
NACS Site naming validation

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -1,8 +1,13 @@
 class Site < ApplicationRecord
   paginates_per 50
 
+  # Removing blank spaces from Site name entered
+  before_validation:strip_whitespace, if: -> {name.present? && name.start_with?('FITS')}
+
   validates :name, presence: true
   validates :name, uniqueness: { case_sensitive: false }, unless: :skip_uniqueness_validation?
+  validates :name, format: { with: /\AFITS-\d{4}-\w+-\w+\z/, message:"Site Name not in expected format : 'FITS-XXXX-TYPE-LOCATION'"}, if: -> {name.present? && name.start_with?('FITS')}
+  
 
   has_many :clients, dependent: :destroy
   has_many :mac_authentication_bypasses, dependent: :destroy
@@ -67,4 +72,11 @@ private
   end
 
   # rubocop:enable Lint/IneffectiveAccessModifier
+
+  # Removes blank spaces from site name 
+  def strip_whitespace
+    self.name = name.strip.gsub(/\s+/, "")
+  end
+
+
 end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -2,12 +2,11 @@ class Site < ApplicationRecord
   paginates_per 50
 
   # Removing blank spaces from Site name entered
-  before_validation:strip_whitespace, if: -> {name.present? && name.start_with?('FITS')}
+  before_validation :strip_whitespace, if: -> { name.present? && name.start_with?("FITS") }
 
   validates :name, presence: true
   validates :name, uniqueness: { case_sensitive: false }, unless: :skip_uniqueness_validation?
-  validates :name, format: { with: /\AFITS-\d{4}-\w+-\w+\z/, message:"Site Name not in expected format : 'FITS-XXXX-TYPE-LOCATION'"}, if: -> {name.present? && name.start_with?('FITS')}
-  
+  validates :name, format: { with: /\AFITS-\d{4}-\w+-\w+\z/, message: "Site Name not in expected format : 'FITS-XXXX-TYPE-LOCATION'" }, if: -> { name.present? && name.start_with?("FITS") }
 
   has_many :clients, dependent: :destroy
   has_many :mac_authentication_bypasses, dependent: :destroy
@@ -73,10 +72,8 @@ private
 
   # rubocop:enable Lint/IneffectiveAccessModifier
 
-  # Removes blank spaces from site name 
+  # Removes blank spaces from site name
   def strip_whitespace
     self.name = name.strip.gsub(/\s+/, "")
   end
-
-
 end

--- a/app/views/sites/_form.html.erb
+++ b/app/views/sites/_form.html.erb
@@ -2,8 +2,8 @@
   <div class="govuk-form-group <%= field_error(f.object, :name) %>">
     <%= f.label :name, class: "govuk-label" %>
     <div id="name-hint" class="govuk-hint">
-      Must contain the FITS ID, type and location in the following format: "FITS-XXXX - TYPE - LOCATION"<br />
-      For example: FITS-1234 - Probation - Maidstone
+      Must contain the FITS ID, type and location in the following format: "FITS-XXXX-TYPE-LOCATION"<br />
+      For example: FITS-1234-Probation-Maidstone
     </div>
     <%= f.text_field :name, maxlength: 230, class: "govuk-input" %>
   </div>

--- a/spec/acceptance/sites/create_sites_spec.rb
+++ b/spec/acceptance/sites/create_sites_spec.rb
@@ -45,8 +45,7 @@ describe "create sites", type: :feature do
       click_on "Create"
 
       # Site name has to be in the format 'FITS-XXXX-TYPE-LOCATION'
-      expect(page). to have_content("Site Name not in expected format : 'FITS-XXXX-TYPE-LOCATION'")
-
+      expect(page).to have_content("Site Name not in expected format : 'FITS-XXXX-TYPE-LOCATION'")
     end
 
     it "can create a new site with site name in valid format" do
@@ -63,7 +62,6 @@ describe "create sites", type: :feature do
       expect(page).to have_content("Successfully created site.")
       expect(page).to have_content("This could take up to 10 minutes to apply.")
       expect(page).to have_content("FITS-9999-Probation-Maidstone")
-
     end
 
     it "creates a new site with a fallback policy" do

--- a/spec/acceptance/sites/create_sites_spec.rb
+++ b/spec/acceptance/sites/create_sites_spec.rb
@@ -32,6 +32,40 @@ describe "create sites", type: :feature do
       login_as editor
     end
 
+    # Test to validate the Site Name format 'FITS-XXXX - TYPE - LOCATION'
+    it "displays error if site name not in expected format : FITS-XXXX-TYPE-LOCATION" do
+      visit "/sites"
+
+      click_on "Create a new site"
+
+      expect(current_path).to eql("/sites/new")
+
+      fill_in "Name", with: "FITS-Probation-Maidstone"
+
+      click_on "Create"
+
+      # Site name has to be in the format 'FITS-XXXX-TYPE-LOCATION'
+      expect(page). to have_content("Site Name not in expected format : 'FITS-XXXX-TYPE-LOCATION'")
+
+    end
+
+    it "can create a new site with site name in valid format" do
+      visit "/sites"
+
+      click_on "Create a new site"
+
+      expect(current_path).to eql("/sites/new")
+
+      fill_in "Name", with: "FITS-9999-Probation-Maidstone"
+
+      click_on "Create"
+
+      expect(page).to have_content("Successfully created site.")
+      expect(page).to have_content("This could take up to 10 minutes to apply.")
+      expect(page).to have_content("FITS-9999-Probation-Maidstone")
+
+    end
+
     it "creates a new site with a fallback policy" do
       visit "/sites"
 
@@ -39,20 +73,20 @@ describe "create sites", type: :feature do
 
       expect(current_path).to eql("/sites/new")
 
-      fill_in "Name", with: "My London Site"
+      fill_in "Name", with: "FITS-9999-Probation-Maidstone"
 
       click_on "Create"
 
       expect(page).to have_content("Successfully created site.")
       expect(page).to have_content("This could take up to 10 minutes to apply.")
-      expect(page).to have_content("My London Site")
+      expect(page).to have_content("FITS-9999-Probation-Maidstone")
       expect(page).not_to have_content("There are no fallback policies attached to this site.")
 
-      click_on "My London Site"
+      click_on "FITS-9999-Probation-Maidstone"
 
       expect(current_path).to eql("/policies/#{Policy.last.id}")
       expect(page).to have_content("Fallback")
-      expect(page).to have_content("My London Site")
+      expect(page).to have_content("FITS-9999-Probation-Maidstone")
 
       expect_audit_log_entry_for(editor.email, "create", "Site")
     end


### PR DESCRIPTION
Site naming validation has been implemented to follow the pattern "FITS-XXXX-TYPE-LOCATION".
Code has been implemented to remove blank space from site name when new site is created.