### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,19 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    # Raise pull requests for version updates
+    # to bundler against the `dependabot` branch
+    target-branch: "dependabot"
+    # Labels on pull requests for version updates only
+    labels:
+      - "bundler dependencies"
+      - "dependabot branch"
+    # Allow up to 100 open pull requests for bundler dependencies
+    open-pull-requests-limit: 100
   - package-ecosystem: "docker"
     directory: "/"
     schedule:


### PR DESCRIPTION
What:
Add target-branch for bundler dependabot.

Why:
Enable scanning of a branch called "dependabot" so that updates can be viewed on non default branch.