### PR TITLE
 updated naming validation to only enforce on new record 

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -3,10 +3,12 @@ class Site < ApplicationRecord
 
   # Removing blank spaces from Site name entered
   before_validation :check_and_prompt_name_correction, if: -> { name.present? && (name.start_with?("FITS") || name.start_with?("MOJO")) && new_record? }
+  before_validation :enforce_uppercase_prefix, if: -> { name.present? && new_record? }
 
   validates :name, presence: true
   validates :name, uniqueness: { case_sensitive: false }, unless: :skip_uniqueness_validation?
-  validates :name, format: { with: /\AFITS-\d{4}-\w+-\w+\z/, message: "Site Name not in expected format : 'FITS-XXXX-TYPE-LOCATION'" }, if: -> { name.present? && (name.start_with?("FITS") || name.start_with?("MOJO")) && new_record? }
+  validates :name, format: { with: /\AFITS-\d{4}-\w+-\w+\z/, message: "Site Name not in expected format : 'FITS-XXXX-TYPE-LOCATION'" }, if: -> { name.present? && name.start_with?("FITS") && new_record? }
+  validates :name, format: { with: /\AMOJO-\d{4}-\w+-\w+\z/, message: "Site Name not in expected format : 'MOJO-XXXX-TYPE-LOCATION'" }, if: -> { name.present? && name.start_with?("MOJO") && new_record? }
 
 
   has_many :clients, dependent: :destroy
@@ -73,14 +75,53 @@ private
 
   # rubocop:enable Lint/IneffectiveAccessModifier
 
-  def check_and_prompt_name_correction
-    cleaned_name = name.strip.gsub(/\s*-\s*/, "-").gsub(/\s+/, "")
+  def enforce_uppercase_prefix
+    if name.present?
+      suggested_name = name.sub(/\A(fits|mojo)/i) { |match| match.upcase }
 
-    if name != cleaned_name
-      errors.add(:name, "Suggested Name: '#{cleaned_name}'. Please confirm if this is acceptable.")
+      # Check if the name needs to be corrected
+      if name != suggested_name
+        errors.add(:name, "Suggested Name: '#{suggested_name}'. Please confirm if this is acceptable.")
+        throw :abort
+      end
+    end
+  end
+  def check_and_prompt_name_correction
+    cleaned_name = name.strip
+    parts = cleaned_name.split('-').map(&:strip)
+
+    if parts.length < 4
+      errors.add(:name, "The name format is invalid. It should have at least 4 parts separated by dashes.")
+      throw :abort
+    end
+
+    prefix = parts[0].upcase
+    number = parts[1][0, 4].rjust(4, '0')
+    # The third part should not be truncated
+    service_type = parts[2]
+    # The location part: replace spaces with underscores
+    location = parts[3..].join('-').gsub(/\s+/, "_")
+
+    corrected_name = "#{prefix}-#{number}-#{service_type}-#{location}"
+
+    fits_format_regex = /\AFITS-\d{4}-\w+-\w+\z/
+    mojo_format_regex = /\AMOJO-\d{4}-\w+-\w+\z/
+
+    # Check format based on the prefix
+    if prefix == "FITS" && corrected_name !~ fits_format_regex
+      errors.add(:name, "Suggested Name: '#{corrected_name}'. Please confirm if this is acceptable. The name must follow the format: 'FITS-XXXX-TYPE-LOCATION'.")
+      throw :abort
+    elsif prefix == "MOJO" && corrected_name !~ mojo_format_regex
+      errors.add(:name, "Suggested Name: '#{corrected_name}'. Please confirm if this is acceptable. The name must follow the format: 'MOJO-XXXX-TYPE-LOCATION'.")
+      throw :abort
+    end
+
+    # Prompt name correction if the name doesn't match the corrected name
+    if name != corrected_name
+      errors.add(:name, "Suggested Name: '#{corrected_name}'. Please confirm if this is acceptable.")
       throw :abort
     else
-      self.name = cleaned_name
+      self.name = corrected_name
     end
   end
 end


### PR DESCRIPTION
- Naming Validation enforced on New records(site) creations only
- Implemented User prompt to choose the name consciously 
- Removed suggested name auto populated
