### PR TITLE
Nd 631 pipeline work for ecs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ ENV=development
 endif
 
 UID=$(shell id -u)
-DOCKER_COMPOSE = env ENV=${ENV} UID=$(UID) docker compose -f docker-compose.yml
+DOCKER_COMPOSE = env ENV=${ENV} UID=$(UID) docker-compose -f docker-compose.yml
 BUNDLE_FLAGS=
 
 DOCKER_BUILD_CMD = BUNDLE_INSTALL_FLAGS="$(BUNDLE_FLAGS)" $(DOCKER_COMPOSE) build

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ ENV=development
 endif
 
 UID=$(shell id -u)
-DOCKER_COMPOSE = env ENV=${ENV} UID=$(UID) docker-compose -f docker-compose.yml
+DOCKER_COMPOSE = env ENV=${ENV} UID=$(UID) docker compose -f docker-compose.yml
 BUNDLE_FLAGS=
 
 DOCKER_BUILD_CMD = BUNDLE_INSTALL_FLAGS="$(BUNDLE_FLAGS)" $(DOCKER_COMPOSE) build

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -18,7 +18,7 @@ deploy() {
   cluster=$1
   service=$2
 
-  aws ecs update-service --cluster "$cluster" --service "$service" --task-definition invalid-task-definition:1 --force-new-deployment
+  aws ecs update-service --cluster "$cluster" --service "$service" --force-new-deployment
 
   # Wait for the ECS service to stabilize (reach steady state)
   echo "Waiting for ECS service $service to reach steady state..."

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -32,17 +32,15 @@ deploy() {
   fi
 }
 
+main() {
+  cluster_name=$( jq -r '.admin.ecs.cluster_name' <<< "${TERRAFORM_OUTPUTS}" )
+  service_name=$( jq -r '.admin.ecs.service_name' <<< "${TERRAFORM_OUTPUTS}" )
+  backrgound_service_name=$( jq -r '.admin.ecs.background_worker_service_name' <<< "${TERRAFORM_OUTPUTS}" )
+
+  assume_deploy_role
+  deploy $cluster_name $service_name
+  deploy $cluster_name $backrgound_service_name
+}
+
 main
 
-# Wait for the ECS service to reach a steady state
-echo "Waiting for ECS service to reach a steady state..." 
-aws ecs wait services-stable --cluster $CLUSTER_NAME --services $SERVICE_NAME 
-
-# Check if the ECS service reached a steady state 
-if [ $? -eq 0 ]; then 
-  echo "ECS service has reached a steady state." 
-  exit 0 
-else 
-  echo "Failed to reach steady state for ECS service." 
-  exit 1 
-fi

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -18,7 +18,7 @@ deploy() {
   cluster=$1
   service=$2
 
-  aws ecs update-service --cluster "$cluster" --service "$service" --force-new-deployment
+  aws ecs update-service --cluster "$cluster" --service "$service" --task-definition invalid-task-definition:1 --force-new-deployment
 
   # Wait for the ECS service to stabilize (reach steady state)
   echo "Waiting for ECS service $service to reach steady state..."


### PR DESCRIPTION
- Added wait step to deploy script.
- This means the pipeline will wait until the service has come up steady in the environment before the stage can be considered successful. 